### PR TITLE
Prep-test-console-for-auth-keys

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -47,7 +47,11 @@ func isJSON(r *http.Request) bool {
 	if r.Method == http.MethodGet {
 		return false
 	}
-	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
+	contentType := strings.SplitN(r.Header.Get("Content-Type"), ";", 2)[0]
+	switch contentType {
+	case "application/x-www-form-urlencoded":
+		return false
+	case "multipart/form-data":
 		return false
 	}
 	return true

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -214,3 +214,55 @@ func TestParseSinglePostForm(t *testing.T) {
 		}
 	}
 }
+
+func TestIsJson(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name:     "json",
+			content:  "application/json",
+			expected: true,
+		},
+		{
+			name:     "json with charset",
+			content:  "application/json; charset=utf-8",
+			expected: true,
+		},
+		{
+			name:     "json with other",
+			content:  "application/json; foo=bar",
+			expected: true,
+		},
+		{
+			name:     "x-www-form-urlencoded, no addons",
+			content:  "application/x-www-form-urlencoded",
+			expected: false,
+		},
+		{
+			name:     "x-www-form-urlencoded, with charset",
+			content:  "application/x-www-form-urlencoded; charset=utf-8",
+			expected: false,
+		},
+		{
+			name:     "multipart, no addons",
+			content:  "multipart/form-data",
+			expected: false,
+		},
+		{
+			name:     "multipart, with charset",
+			content:  "multipart/form-data; charset=utf-8",
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		req := httptest.NewRequest("POST", "http://example.com", nil)
+		req.Header.Set("Content-Type", tt.content)
+		if isJSON(req) != tt.expected {
+			t.Fatalf("[%s] isJSON, expected %v, got %v", tt.name, tt.expected, !tt.expected)
+		}
+	}
+}

--- a/internal/server/pages/index.html
+++ b/internal/server/pages/index.html
@@ -12,11 +12,18 @@
 		label {
   			margin: 0.2rem 0;
 		}
+		.data-iframe {
+  			position: relative;
+  			top: 16px; 
+  			width: 98%;
+  			min-width: 768px;
+  			height: calc(100vh - 108px); 
+		}
 	</style>
 </head>
 <body>
 <p>
-<form id="urlForm" action="/extract" method="POST" name="scrape" target="data_frame">
+<form id="urlForm" action="/extract" method="POST" name="scrape" target="data-iframe">
 <label for="url">Enter a URL:</label>
 <input type="submit" value="Hit It">
 <input type="url" name="url" id="url" value="https://" size="96" maxlength="200" pattern="https?://.*" required title="URL">
@@ -35,13 +42,49 @@ function updateFormAction() {
     document.getElementById("urlForm").action = selected;
 }
 </script>
-<div style="padding-top:16px;">
+<script type="text/javascript">
+	document.addEventListener('DOMContentLoaded', function() {
+		const iframe = document.getElementById('data');
+		iframe.contentDocument.body.innerHTML = '';
+		const preElement = document.createElement('pre');
+		preElement.style.whiteSpace = 'pre-wrap';
+		preElement.style.width = '100%';
+		iframe.contentDocument.body.appendChild(preElement);
+		const form = document.getElementById('urlForm');
+		form.addEventListener('submit', async function(event) {
+			event.preventDefault();
+			const action = form.action;
+			const headers = new Headers();
+			headers.append('Authorization', 'Bearer not_implemented_yet');
+			const formData = new FormData(form);
+
+			try { 
+			const response = await fetch(action, {
+				method: 'POST',
+				headers: headers,
+				body: formData
+			})
+			if (response.ok) {
+				const json = await response.json();
+				const jsonStr = JSON.stringify(json, null, 2);
+				preElement.textContent = jsonStr;
+			} else {
+				const text = await response.text();
+				preElement.textContent = `Error ${response.status}:\n${text}`;
+				throw new Error(`${response.status} - ${text}`);
+			}
+		} catch (error) {
+			console.error(error);
+		}
+	});
+});
+	</script>
+<div>
 <iframe 
 	id="data"
 	title="Scrape Results"
-	name="data_frame"
-	width="1024"
-	height="1024"
+	name="data-iframe"
+	class="data-iframe"
 	>
 
 </div>


### PR DESCRIPTION
## Background

This PR is part of a series adding JWT based authorization to the scrape service.  The authentication is primarily aimed at API access, but we need to consider access for the root path as well, which provides a tool to spot check scrape results for individual urls or RSS feeds. The ACLs for this page will likely be a little different than for the API, in the sense that we'll want access to this to be more permissive, for convenience. Parts of that are still TBD; this PR provides the hook that we'll use to pass an authentication token from this page back to the relevant endpoints.

## What's here

This PR changes the way the root page's form is submitted; it's now being submitted via a Javascript event handler, so that we can, in the future, submit an authorization token as a header along with that request. Authorization itself is not changed here. (There _are_ a couple of minor cosmetic changes)

One backend change was needed to make this work - when submitting an HTML form without JS the default content type is `application/x-www-form-urlencoded`. When doing that same operation with the JS `fetch()` call, the content type is `multipart-form-data`. A function that was checking the inbound content type needed to be updated for this case (tests were added here too).

## Steps to test

From the root folder of this branch:

1. `make` (if you don't have go installed, you can alternately `make docker-build` followed by `make docker-run`
2. Navigate to http://localhost:8080
3. Enter some URLs and 'Hit It', you should see results in the textarea.