### PR TITLE
Embed a [short lived] JWT token into the test console

### DIFF
--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -62,6 +62,13 @@ func (c Claims) Sign(key HMACBase64Key) (string, error) {
 	return c.Token().SignedString([]byte(key))
 }
 
+func ExpiresIn(d time.Duration) option {
+	return func(c *Claims) error {
+		c.ExpiresAt = jwt.NewNumericDate(time.Now().Add(d))
+		return nil
+	}
+}
+
 func ExpiresAt(t time.Time) option {
 	return func(c *Claims) error {
 		if t.Before(time.Now()) {

--- a/internal/server/pages/index.html
+++ b/internal/server/pages/index.html
@@ -55,7 +55,10 @@ function updateFormAction() {
 			event.preventDefault();
 			const action = form.action;
 			const headers = new Headers();
-			headers.append('Authorization', 'Bearer not_implemented_yet');
+			const token = '{{AuthToken}}'
+			if (token) {
+				headers.append('Authorization', `Bearer ${token}`);
+			}
 			const formData = new FormData(form);
 
 			try { 


### PR DESCRIPTION
## Background

This PR continues the series of PRs enabling JWT-based authorization for `scrape`. Prior PRs in this series:

1. [JWT Generation and Verification](https://github.com/Pocket/scrape/pull/1)
1. [Prep test console for auth keys](https://github.com/Pocket/scrape/pull/2)

## What's Here

This PR embeds a JWT Token into the source of the test console's html, so that the test console has a token to pass in along with its API request. This token is a short-lived token and is intended to provide spot access to the test console without requiring key interactions, and also to provide a way to exercise/develop the end-to-end token interactions easlily and without system disruptions (In an IAP future, IAP would be participating in this interaction and there's likely a scoping mechanism applied to this token).

In order to support configuring authorization, an argument/env variable for a signing key has been added to `scrape-server`. If this key is provided and valid, authorization will be enabled.

At this time, enabling authorization just gets a token embedded in the page source and passed into the server on form submits. Authorization is not checked or enforced in this PR, that will come in a follow-on PR.

## Steps To Test 

From the root directory of this branch:

1. `make`
1. `make test` - if you want to confirm that the tests pass
1. start the server with `./build/scrape-server` (`-h` if you want to see the docs)
1. In your browser navigate to http://127.0.0.1:8080
1. Do a `View Source` you will see an empty token assignment in the JS function near the bottom, it'll look like this:
```
...
const token = ''
if (token) {
	headers.append('Authorization', `Bearer ${token}`);
}
...
```

Now, make a signing key and restart the server using that key:

1. Control-c in your shell window from above to quit the server
1. ./build/scrape-jwt-encode -make-key` . 
1. `./build/scrape-server -signing-key [the key you got above]` or set a shell variable of `SCRAPE_SIGNING_KEY` to the key value and start the server without arguments.
1. In your browser reload http://127.0.0.1:8080
1. Do a `View Source` you will see a populated token assignment in the JS function near the bottom, it'll look like this:
```
...
const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY3JhcGUiLCJzdWIiOiJob21lIiwiZXhwIjoxNzE1NzE0MTg1LCJpYXQiOjE3MTU3MTA1ODV9.fjmKe2-NmROV_f0-X3QBFFXO8QvTm_05nGPufCukPiE'
if (token) {
	headers.append('Authorization', `Bearer ${token}`);
}
...
```
That's it! (You can also do the above from the Docker build)

If you don't have go installed, you'll need to install go (on the Mac easiest to do with `brew`. You'll also need to `go install honnef.co/go/tools/cmd/staticcheck@latest` to run static analysis (which happens as part of `make`)





