### PR TITLE
Enable Authorization (Optionally) for API Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Flags:
 ## Usage as a Server
 The server provides a REST API to get resource data one-at-a-time or in bulk. The root URL serves up a page that can be used to spot check results for any url.
 
-`scrape-server` is robust but does not support any authentication or rate limiting at this time. Keep that in mind when deploying.
+Running `scrape-server` with no arguments will bring up a server on port 8080 with a SQLite database, storing scraped pages for 30 days and without any authorization controls. See below for guidance on how to change these settings.
 
 ### Installation
 ```
@@ -210,13 +210,16 @@ Command line options:
         Environment: SCRAPE_ENABLE_HEADLESS
   -log-level value
         Set the log level [debug|error|info|warn]
-        Environment: SCRAPE_LOG_LEVEL
+        Environment: SCRAPE_LOG_LEVEL (default info)
   -port value
         Port to run the server on
         Environment: SCRAPE_PORT (default 8080)
   -profile
         Enable profiling at /debug/pprof
         Environment: SCRAPE_PROFILE
+  -signing-key value
+        Base64 encoded HS256 key to verify JWT tokens. Required for JWT auth, and enables JWT auth if set.
+        Environment: SCRAPE_SIGNING_KEY
   -ttl value
         TTL for fetched resources
         Environment: SCRAPE_TTL (default 720h0m0s)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Fast web scraping
   - [Web Interface](#web-interface)
   - [API](#api)
   - [Healthchecks](#healthchecks)
+  - [Authorization](#authorization)
 - [Database Options](#database-options)
 - [Building and Developing](#building-and-developing)
   - [Building](#building)
@@ -23,13 +24,16 @@ Fast web scraping
 - [Acknowledgements](#acknowledgements)
 
 ## Description
-`scrape` provides a self-contained low-to-no-setup tool to grab metadata and text content from web pages. The server provides a REST API to scrape web metadata, with support for batches, using either a direct client, with headless browser option that's useful for pages that need javascript to load.
+`scrape` provides a self-contained low-to-no-setup tool to grab metadata and text content from web pages. The server provides a REST API to scrape web metadata, with support for batches, using either a direct client, with headless browser option that's useful for pages that need javascript to load. 
 
  Results are stored, so subsequent fetches of a particular URL are fast. Install the binary, and operate it as a shell command or as a server with a REST API. The default SQLite storage backend is performance-optimized and can store to disk or in memory. MySQL is also supported. Resources are stored with a configurable TTL. 
 
  The `scrape` cli tool provides shell access to scraped content via command-line entry or CSV files, and also provides database management functionality. `scrape-server` provides web and API access to content metadata in one-offs or batches.
 
  RSS and Atom feeds are supported via an endpoint in `scrape-server`. Loading a feed returns the parsed results for all item links in the feed. 
+
+ Authorization via JWT keys is supported with a configuration option. The companion `scrape-jwt-encode` tool can be used to generate tokens, and to make the secret you need 
+ to securely  sign and verify JWT tokens. 
 
  The `scrape` and `scrape-server` binaries should be buildable and runnable in any environment where `go` and `SQLite3` (or a `MySQL` server) are present. A docker build is also included. See `make help` for build instructions.
 
@@ -310,6 +314,98 @@ database runtime info.
 #### /.well-known/heartbeat
 
 This just returns a status `200` with the content `OK`
+
+### Authorization
+
+By default, `scrape` runs without any authorization, all endpoints are open. JWT based authentication is supported, via the `scrape-jwt-encode` tool and a `scrape-server` configuration option. Here's how to enable it:
+
+#### Generate a Secret
+
+(`./build` is the path for executables built locally with `make` update this path if your binaries are elsewhere)
+
+Running `scrape-jwt-encode` with the `make-key` flag will generate a cryptographically random HS256 secret, and encode it to Base64.
+
+```
+scrape % ./build/scrape-jwt-encode -make-key
+Be sure to save this key, as it can't be re-generated:
+b4RThFbyMKfQE3+jAjJcR5rjVgVOeA2Ub9eethtX83M=
+```
+
+You will need this secret to generate tokens and to configure the server for authentication; you'll need to save it, but don't share it via non-secure means, etc.
+
+If the key is in your environment as `SCRAPE_SIGNING_KEY` it'll be picked up by both the JWT encoding tool and the server.
+
+#### Generate Tokens
+
+Tokens are also generated using `scrape-jwt-encode`. Here's the output of `scrape-jwt-encode -h`: 
+
+```
+scrape % ./build/scrape-jwt-encode -h       
+
+Generates JWT tokens for the scrape service. Also makes the signing key to use for the tokens.
+
+Usage: 
+-----
+scrape-jwt-encode -sub subject [-signing-key key] [-exp expiration] [-aud audience]
+scrape-jwt-encode -make-key
+
+  -aud string
+        Audience (recipient) for the key (default "moz")
+  -exp value
+        Expiration date for the key, in RFC3339 format. Default is 1 year from now. (default 2025-05-16T11:45:45.842362-04:00)
+  -make-key
+        Generate a new signing key
+  -signing-key value
+        HS256 key to sign the JWT token
+        Environment: SCRAPE_SIGNING_KEY (default &[])
+  -sub string
+        Subject (holder name) for the key (required)
+```
+
+When generating a key, only a `subject` is required. Authorization doesn't actually check this value, but it's a good idea to use unique identifying values here, as this may get used in the future and may also get logged.
+
+Here's the output from token generation, after putting the key from above into the environment. The claims are printed out for reference, but it's the token at the bottom that you want to share with API consumers.
+
+```
+scrape % export SCRAPE_SIGNING_KEY=b4RThFbyMKfQE3+jAjJcR5rjVgVOeA2Ub9eethtX83M=
+scrape % ./build/scrape-jwt-encode -sub some_user
+
+Claims:
+------
+{
+  "iss": "scrape",
+  "sub": "some_user",
+  "aud": [
+    "moz"
+  ],
+  "exp": 1747410570,
+  "iat": 1715874570
+}
+
+Token:
+-----
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY3JhcGUiLCJzdWIiOiJzb21lX3VzZXIiLCJhdWQiOlsibW96Il0sImV4cCI6MTc0NzQxMDU3MCwiaWF0IjoxNzE1ODc0NTcwfQ.4AapsWfYAK78JhP9AyhupmZAHLeRDyIPlE8ODwwsVRg
+```
+
+### Using Tokens When Making API Requests
+
+When authorization is enabled on the server, API requests must have an `Authorization` header that begins with the string `Bearer ` (with a space) followed by the token.
+
+### Enabling Authorization In `scrape-server`
+
+To enable authorization on the server either:
+
+1. Start the server with the `SCRAPE_SIGNING_KEY` environment variable
+2. Pass a `-signing-key [key]` argument to the server when starting up
+
+When enabled, `scrape` will check the following qualities of the token, and reject API requests with a `401` unless there is a token passed in the `Authorization` header fulfilling the following criteria:
+
+1. It's a valid JWT token
+2. The token has been signed with the same signing key that the server is using
+3. The token's issuer is `scrape`
+4. The token is not expired
+
+Healthcheck paths don't require authorization, and neither does the web interface at the root URL. (The test console uses a short-lived key to authorize requests -- it _is_ possible to lift a key from here and use it for a little while; trying to strike a balance here between securing access and making exercising the server easy. You will also need to reload the test console periodically or calls from here will 401 as well)
 
 ## Database Options
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -36,7 +36,7 @@ func JWTAuthMiddleware(
 			if err != nil {
 				http.Error(
 					w,
-					fmt.Sprintf("Invalid Token %q: %v", token, err),
+					fmt.Sprintf("Invalid Token - %v", err),
 					http.StatusUnauthorized,
 				)
 				return

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -9,17 +9,16 @@ import (
 
 type ClaimsAuthorizer func(claims *Claims) error
 
-//type AuthHandler func
-
 // Checks the Authorization header for a JWT token and verifies it using the provided key.
 // The token is always validated against the HMAC key, the issuer, and the Claims.Validate
 // function.
 //
-// The ClaimsAuthorizer functions, if any are called in order. If any of them return an
+// The ClaimsAuthorizer functions, if any, are called in order. If any of them return an
 // error, the request is rejected with a 401 Unauthorized status and the error message
 // is written to the response body.
 //
-// If the token is valid, the claims are added to the request context.
+// If the token is valid, the claims are added to the request context at the key value
+// specified by contextKey.
 func JWTAuthMiddleware(
 	key HMACBase64Key,
 	contextKey any,
@@ -34,20 +33,14 @@ func JWTAuthMiddleware(
 			}
 			claims, err := VerifyToken(key, strings.TrimSpace(token))
 			if err != nil {
-				http.Error(
-					w,
-					fmt.Sprintf("Invalid Token - %v", err),
-					http.StatusUnauthorized,
-				)
+				msg := fmt.Sprintf("Invalid Token - %v", err)
+				http.Error(w, msg, http.StatusUnauthorized)
 				return
 			}
 			for _, c := range cc {
 				if err := c(claims); err != nil {
-					http.Error(
-						w,
-						fmt.Sprintf("Not authorized for this request: %v", err),
-						http.StatusUnauthorized,
-					)
+					msg := fmt.Sprintf("Not authorized for this request: %v", err)
+					http.Error(w, msg, http.StatusUnauthorized)
 					return
 				}
 			}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type Middleware func(http.HandlerFunc) http.HandlerFunc
+
+//type AuthHandler func
+
+func JWTAuthMiddleware(key HMACBase64Key, contextKey any) Middleware {
+	return func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			_, token, found := strings.Cut(r.Header.Get("Authorization"), " ")
+			if !found || (token == "") {
+				http.Error(w, "No Authorization Passed", http.StatusUnauthorized)
+				return
+			}
+			claims, err := VerifyToken(key, strings.TrimSpace(token))
+			if err != nil {
+				http.Error(
+					w,
+					fmt.Sprintf("Invalid Token %q: %v", token, err),
+					http.StatusUnauthorized,
+				)
+				return
+			}
+			r = r.WithContext(context.WithValue(r.Context(), contextKey, claims))
+			next(w, r)
+		}
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 )
 
-type Middleware func(http.HandlerFunc) http.HandlerFunc
 type ClaimsAuthorizer func(claims *Claims) error
 
 //type AuthHandler func
@@ -21,7 +20,11 @@ type ClaimsAuthorizer func(claims *Claims) error
 // is written to the response body.
 //
 // If the token is valid, the claims are added to the request context.
-func JWTAuthMiddleware(key HMACBase64Key, contextKey any, cc ...ClaimsAuthorizer) Middleware {
+func JWTAuthMiddleware(
+	key HMACBase64Key,
+	contextKey any,
+	cc ...ClaimsAuthorizer,
+) func(http.HandlerFunc) http.HandlerFunc {
 	return func(next http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			_, token, found := strings.Cut(r.Header.Get("Authorization"), " ")

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -83,12 +83,13 @@ func TestJWTAuthMiddleWare(t *testing.T) {
 		req.Header.Set("Authorization", tt.authHeader)
 		m := JWTAuthMiddleware(tt.key, contextKey{}, tt.extra...)
 
-		m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m(func(w http.ResponseWriter, r *http.Request) {
 			claims, ok := r.Context().Value(contextKey{}).(*Claims)
 			if !ok {
 				t.Fatalf("[%s] JWTAuthMiddleware, expected claims, got %v", tt.name, claims)
 			}
-		}))(recorder, req)
+		})(recorder, req)
+
 		response := recorder.Result()
 		if response.StatusCode != tt.expectStatus {
 			body, _ := io.ReadAll(response.Body)

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,83 @@
+package auth
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestJWTAuthMiddleWare(t *testing.T) {
+	t.Parallel()
+	realKey := MustNewHS256SigningKey()
+	c, _ := NewClaims(
+		ExpiresAt(time.Now().Add(24*time.Hour)),
+		WithSubject("subject"),
+		WithAudience("audience"),
+	)
+	token, _ := c.Sign(realKey)
+	tests := []struct {
+		name         string
+		key          HMACBase64Key
+		authHeader   string
+		expectStatus int
+	}{
+		{
+			name:         "no auth",
+			key:          realKey,
+			authHeader:   "",
+			expectStatus: http.StatusUnauthorized,
+		},
+		{
+			name:         "valid auth",
+			key:          realKey,
+			authHeader:   fmt.Sprintf("Bearer %s", token),
+			expectStatus: http.StatusOK,
+		},
+		{
+			name:         "No token in header",
+			key:          realKey,
+			authHeader:   "Bearer",
+			expectStatus: http.StatusUnauthorized,
+		},
+		{
+			name:         "Garbage token in header",
+			key:          realKey,
+			authHeader:   "Bearer llkllKjLKDLD.kkajhdakjsdhakdjh.ajkshdakjshd",
+			expectStatus: http.StatusUnauthorized,
+		},
+		{
+			name:         "Only token in header",
+			key:          realKey,
+			authHeader:   token,
+			expectStatus: http.StatusUnauthorized,
+		},
+		{
+			name:         "Key mismatch",
+			key:          MustNewHS256SigningKey(),
+			authHeader:   fmt.Sprintf("Bearer %s", token),
+			expectStatus: http.StatusUnauthorized,
+		},
+	}
+	type contextKey struct{}
+	for _, tt := range tests {
+		req := httptest.NewRequest("GET", "http://example.com", nil)
+		recorder := httptest.NewRecorder()
+		req.Header.Set("Authorization", tt.authHeader)
+		m := JWTAuthMiddleware(tt.key, contextKey{})
+
+		m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			claims, ok := r.Context().Value(contextKey{}).(*Claims)
+			if !ok {
+				t.Fatalf("[%s] JWTAuthMiddleware, expected claims, got %v", tt.name, claims)
+			}
+		}))(recorder, req)
+		response := recorder.Result()
+		if response.StatusCode != tt.expectStatus {
+			body, _ := io.ReadAll(response.Body)
+			t.Fatalf("[%s] JWTAuthMiddleware, expected status %d, got %d (%s)", tt.name, tt.expectStatus, response.StatusCode, body)
+		}
+	}
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -16,8 +16,7 @@ type middleware func(http.HandlerFunc) http.HandlerFunc
 
 type payloadKey struct{}
 
-// type fetcherKey struct{}
-
+// Prepend the middlewares to the handler in the order they are provided.
 func Chain(h http.HandlerFunc, m ...middleware) http.HandlerFunc {
 	if len(m) == 0 {
 		return h

--- a/internal/server/pages/index.html
+++ b/internal/server/pages/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
 	<meta charset="utf-8" />

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -94,6 +94,7 @@ func NewScrapeServer(
 
 type claimsKey struct{}
 
+// Prepend the authorization checker to the list of passed middleware if authorization is enabled.
 func (ss scrapeServer) withAuthIfEnabled(ms ...middleware) []middleware {
 	if len(ss.SigningKey) > 0 {
 		ms = append([]middleware{auth.JWTAuthMiddleware(ss.SigningKey, claimsKey{})}, ms...)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -36,7 +36,7 @@ func InitMux(scrapeServer *scrapeServer) (*http.ServeMux, error) {
 	mux.HandleFunc("GET /extract/headless", h)
 	mux.HandleFunc("POST /extract/headless", h)
 	mux.HandleFunc("POST /batch", scrapeServer.batchHandler())
-	mux.HandleFunc("DELETE /{$}", scrapeServer.deleteHandler())
+	mux.HandleFunc("DELETE /extract", scrapeServer.deleteHandler())
 	h = scrapeServer.feedHandler()
 	mux.HandleFunc("GET /feed", h)
 	mux.HandleFunc("POST /feed", h)
@@ -120,7 +120,7 @@ var home embed.FS
 func (h scrapeServer) mustHomeTemplate() *template.Template {
 	tmpl := template.New("home")
 	var keyF = func() string { return "" }
-	if (h.SigningKey != nil) && (len(h.SigningKey) > 0) {
+	if len(h.SigningKey) > 0 {
 		keyF = func() string {
 			c, err := auth.NewClaims(
 				auth.WithSubject("home"),

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -141,7 +141,6 @@ func (h scrapeServer) mustHomeTemplate() *template.Template {
 	tmpl = tmpl.Funcs(template.FuncMap{"AuthToken": keyF})
 	homeSource, _ := home.ReadFile("pages/index.html")
 	tmpl = template.Must(tmpl.Parse(string(homeSource)))
-	tmpl.Option("missingkey=zero")
 	return tmpl
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -92,6 +92,15 @@ func NewScrapeServer(
 	return handler, nil
 }
 
+type claimsKey struct{}
+
+func (ss scrapeServer) withAuthIfEnabled(ms ...middleware) []middleware {
+	if len(ss.SigningKey) > 0 {
+		ms = append([]middleware{auth.JWTAuthMiddleware(ss.SigningKey, claimsKey{})}, ms...)
+	}
+	return ms
+}
+
 // Convenience method to get the underlying storage from the fetcher
 // which we use for healthchecks.
 // TODO: Re-evaluate. The underlying DB should probably be exposed via an
@@ -150,16 +159,13 @@ func (h scrapeServer) homeHandler() http.HandlerFunc {
 	}
 }
 
-func (h *scrapeServer) singleHandler() http.HandlerFunc {
-	return Chain(h.extract, MaxBytes(4096), parseSinglePayload())
+func (ss *scrapeServer) singleHandler() http.HandlerFunc {
+	return Chain(ss.extract, ss.withAuthIfEnabled(MaxBytes(4096), parseSinglePayload())...)
 }
 
-func (h *scrapeServer) singleHeadlessHandler() http.HandlerFunc {
-	return Chain(
-		extractWithFetcher(h.headlessFetcher),
-		MaxBytes(4096),
-		parseSinglePayload(),
-	)
+func (ss *scrapeServer) singleHeadlessHandler() http.HandlerFunc {
+	ms := ss.withAuthIfEnabled(MaxBytes(4096), parseSinglePayload())
+	return Chain(extractWithFetcher(ss.headlessFetcher), ms...)
 }
 
 // The nested handler here is the same as the one below, just enclosed around a fetcher.
@@ -236,8 +242,9 @@ func (h *scrapeServer) extract(w http.ResponseWriter, r *http.Request) {
 	encoder.Encode(page)
 }
 
-func (h *scrapeServer) batchHandler() http.HandlerFunc {
-	return Chain(h.batch, MaxBytes(32768), DecodeJSONBody[BatchRequest]())
+func (ss *scrapeServer) batchHandler() http.HandlerFunc {
+	ms := ss.withAuthIfEnabled(MaxBytes(32768), DecodeJSONBody[BatchRequest]())
+	return Chain(ss.batch, ms...)
 }
 
 func (h *scrapeServer) batch(w http.ResponseWriter, r *http.Request) {
@@ -278,17 +285,18 @@ func (h *scrapeServer) batch(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h scrapeServer) deleteHandler() http.HandlerFunc {
-	return Chain(h.delete, MaxBytes(4096), parseSinglePayload())
+func (ss *scrapeServer) deleteHandler() http.HandlerFunc {
+	ms := ss.withAuthIfEnabled(MaxBytes(4096), parseSinglePayload())
+	return Chain(ss.delete, ms...)
 }
 
-func (h scrapeServer) delete(w http.ResponseWriter, r *http.Request) {
+func (ss *scrapeServer) delete(w http.ResponseWriter, r *http.Request) {
 	req, ok := r.Context().Value(payloadKey{}).(*singleURLRequest)
 	if !ok {
 		http.Error(w, "Can't process delete request, no input data", http.StatusInternalServerError)
 		return
 	}
-	deleter, ok := h.urlFetcher.(*scrape.StorageBackedFetcher)
+	deleter, ok := ss.urlFetcher.(*scrape.StorageBackedFetcher)
 	if !ok {
 		http.Error(w, "Can't delete in the current configuration", http.StatusNotImplemented)
 		return
@@ -324,8 +332,9 @@ func (h *scrapeServer) synchronousBatch(urls []string, encoder *jsonarray.Encode
 	}
 }
 
-func (h *scrapeServer) feedHandler() http.HandlerFunc {
-	return Chain(h.feed, MaxBytes(4096), parseSinglePayload())
+func (ss *scrapeServer) feedHandler() http.HandlerFunc {
+	ms := ss.withAuthIfEnabled(MaxBytes(4096), parseSinglePayload())
+	return Chain(ss.feed, ms...)
 }
 
 func (h *scrapeServer) feed(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -387,3 +387,64 @@ func TestMustTemplate(t *testing.T) {
 		}
 	}
 }
+
+// Test that a request to the relevant API routes without a valid token
+// is rejected when running with a signing key.
+// Since the auth middleware is (and always should be) placed in the
+// middleware chain before the actual handler, we don't need to set up
+// a request body - the request should get rejected before that would get
+// evaluated.
+func TestAPIRoutesAreProtected(t *testing.T) {
+	ss := &scrapeServer{SigningKey: auth.MustNewHS256SigningKey()}
+	tests := []struct {
+		name     string
+		method   string
+		handler  func() http.HandlerFunc
+		expected int
+	}{
+		{
+			name:    "/extract",
+			method:  http.MethodPost,
+			handler: ss.singleHandler,
+		},
+		{
+			name:    "/extract",
+			method:  http.MethodGet,
+			handler: ss.singleHandler,
+		},
+		{
+			name:    "/extract/headless",
+			method:  http.MethodPost,
+			handler: ss.singleHeadlessHandler,
+		},
+		{
+			name:    "/extract/batch",
+			method:  http.MethodPost,
+			handler: ss.batchHandler,
+		},
+		{
+			name:    "DELETE",
+			method:  http.MethodDelete,
+			handler: ss.deleteHandler,
+		},
+		{
+			name:    "/feed",
+			method:  http.MethodGet,
+			handler: ss.feedHandler,
+		},
+		{
+			name:    "/feed",
+			method:  http.MethodPost,
+			handler: ss.feedHandler,
+		},
+	}
+	for _, test := range tests {
+		req := httptest.NewRequest(test.method, "http://foo.bar", nil)
+		w := httptest.NewRecorder()
+		test.handler()(w, req)
+		resp := w.Result()
+		if resp.StatusCode != 401 {
+			t.Fatalf("[%s] Expected 401, got %d", test.name, resp.StatusCode)
+		}
+	}
+}

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -397,43 +397,42 @@ func TestMustTemplate(t *testing.T) {
 func TestAPIRoutesAreProtected(t *testing.T) {
 	ss := &scrapeServer{SigningKey: auth.MustNewHS256SigningKey()}
 	tests := []struct {
-		name     string
-		method   string
-		handler  func() http.HandlerFunc
-		expected int
+		name    string
+		method  string
+		handler func() http.HandlerFunc
 	}{
 		{
-			name:    "/extract",
+			name:    "POST /extract",
 			method:  http.MethodPost,
 			handler: ss.singleHandler,
 		},
 		{
-			name:    "/extract",
+			name:    "GET /extract",
 			method:  http.MethodGet,
 			handler: ss.singleHandler,
 		},
 		{
-			name:    "/extract/headless",
+			name:    "POST /extract/headless",
 			method:  http.MethodPost,
 			handler: ss.singleHeadlessHandler,
 		},
 		{
-			name:    "/extract/batch",
+			name:    "POST /extract/batch",
 			method:  http.MethodPost,
 			handler: ss.batchHandler,
 		},
 		{
-			name:    "DELETE",
+			name:    "DELETE /extract",
 			method:  http.MethodDelete,
 			handler: ss.deleteHandler,
 		},
 		{
-			name:    "/feed",
+			name:    "GET /feed",
 			method:  http.MethodGet,
 			handler: ss.feedHandler,
 		},
 		{
-			name:    "/feed",
+			name:    "POST /feed",
 			method:  http.MethodPost,
 			handler: ss.feedHandler,
 		},


### PR DESCRIPTION
This PR enables the first iteration of JWT-based authorization to `scrape` endpoints, via a new middleware.

I'll skip most the usual PR info here in favor of [linking to the documentation updates](https://github.com/Pocket/scrape/blob/c7f869fc98fe2afc54e43cbc8d9a9bfafd378e70/README.md#authorization) that step through the process of using authorization and details about how authorization is granted.

## Steps to Test

To test this PR, first follow the steps in the docs, and then issue a request like this:

```
POST http://localhost:8080/extract
Content-Type: application/json
Authorization: Bearer PUT_YOUR_TOKEN_HERE

{
    "url": "https://road.cc/content/tech-news/zipps-new-tyres-ensure-safe-retention-hookless-rims-308387",
    "pp": true
}
```
Also, try it without a token or with a bad token once you've enabled auth.

NB: There are a couple of tiny changes in this PR that aren't directly related to enabling the auth function, just some small/dumb things I noticed.