### PR TITLE
Refactor test console ahead of upcoming auth changes

### DIFF
--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -32,6 +32,7 @@
 			padding-block: 0.2rem;
 			padding-inline: 0.4rem;
 			box-sizing: border-box;
+			user-select: text;
 		}
 		pre {
 			white-space: pre-wrap;
@@ -39,13 +40,13 @@
 		}
 		label {
 			display: block;
-			font: 1rem 'Verdana'
+			font-family: Verdana, Arial, Helvetica, sans-serif;
+			font-size: 1.0rem;
 		}
 		input,
 		label {
   			margin: 0.2rem 0;
 		}
-		
 	</style>
 </head>
 <body>
@@ -53,13 +54,13 @@
 <div class="controls-container">
 <form x-data="formHandler" @submit.prevent="handleSubmit">
 <label for="url">Enter a URL:</label>
-<input type="submit" value="Hit It">
-<input type="url" name="url" id="url" value="https://" size="96" maxlength="200" pattern="https?://.*" required title="URL">
 <select title="URL Type" x-model="formAction">
 	<option value="/extract">Page</option>
 	<option value="/extract/headless">Headless</option>
 	<option value="/feed">Feed</option>
 </select>
+<input type="url" name="url" id="url" value="https://" size="96" maxlength="200" pattern="https?://.*" required title="URL">
+<input type="submit" value="Hit It">
 <!-- <label for="token">Token:</label> -->
 <input type="hidden" name="token" size="101" maxlength="255" value="{{AuthToken}}" placeholder="Enter your access token">
 <input type="hidden" name="pp" value="1">

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -60,8 +60,8 @@
 	<option value="/extract/headless">Headless</option>
 	<option value="/feed">Feed</option>
 </select>
-<label for="token">Token:</label>
-<input type="text" name="token" size="101" maxlength="255" value="{{AuthToken}}" placeholder="Enter your access token">
+<!-- <label for="token">Token:</label> -->
+<input type="hidden" name="token" size="101" maxlength="255" value="{{AuthToken}}" placeholder="Enter your access token">
 <input type="hidden" name="pp" value="1">
 </form>
 </div><!-- controls-container -->

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -14,24 +14,29 @@
 		label {
   			margin: 0.2rem 0;
 		}
-		.data-iframe {
-  			position: relative;
-  			top: 16px; 
-  			width: 98%;
-  			min-width: 768px;
-  			height: calc(100vh - 108px); 
+		pre {
+			white-space: pre-wrap;
+			width: 100%;
+		}
+		.response-container {
+			width: 100%;
+			min-width: 768px;
+			height: calc(100vh - 108px);
+			overflow: auto;
+			border: 0.1rem inset #ccc;
+			padding-block: 0.0rem;
+			padding-inline: 0.4rem;
+			box-sizing: border-box;			
 		}
 	</style>
 </head>
 <body>
 <p>
-<form action="/extract" x-data="formHandler" @submit.prevent="handleSubmit">
-
-<!-- <form id="urlForm" action="/extract" method="POST" name="scrape" target="data-iframe" x-data="formHandler" @submit.prevent="handleSubmit"> -->
+<form x-data="formHandler" @submit.prevent="handleSubmit">
 <label for="url">Enter a URL:</label>
 <input type="submit" value="Hit It">
 <input type="url" name="url" id="url" value="https://" size="96" maxlength="200" pattern="https?://.*" required title="URL">
-<select title="URL Type" id="actionSelect" onchange="updateFormAction()">
+<select title="URL Type" x-model="formAction">
 	<option value="/extract">Page</option>
 	<option value="/extract/headless">Headless</option>
 	<option value="/feed">Feed</option>
@@ -40,18 +45,16 @@
 <input type="hidden" name="pp" value="1">
 </form>
 </p>
-<script>
-function updateFormAction() {
-    var selected = document.getElementById("actionSelect").value;
-    document.getElementById("urlForm").action = selected;
-}
-</script>
+<div class="response-container">
+	<pre x-ref="responseContent" id="responseContent"></pre>
+</div> 
+
 <script type="text/javascript">
 	function formHandler() {
 		return {
+			formAction: '/extract',
 			async handleSubmit(event) {
 				const form = event.target;
-				const action = form.action;
 				const headers = new Headers();
 				const token = form.token.value;
 				if (token) {
@@ -60,7 +63,7 @@ function updateFormAction() {
 				const formData = new FormData(form);
 				formData.delete('token');
 				try { 
-					const response = await fetch(action, {
+					const response = await fetch(this.formAction, {
 						method: 'POST',
 						headers: headers,
 						body: formData
@@ -80,63 +83,13 @@ function updateFormAction() {
 				}
 			},
 			updateContent(content) {
-				const iframe = document.getElementById('data');
-                const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
-				const preElement = iframeDoc.getElementById('responseContent');
-				preElement.textContent = content;
+				document.getElementById('responseContent').textContent = content;
+				// following should work but doesn't
+				// this.$refs.responseContent.textContent = content;
 			}
 		}
 	}
 </script>
 
-<script type="text/javascript">
-	document.addEventListener('DOMContentLoaded', function() {
-		const iframe = document.getElementById('data');
-		iframe.contentDocument.body.innerHTML = '';
-		const preElement = document.createElement('pre');
-		preElement.style.whiteSpace = 'pre-wrap';
-		preElement.style.width = '100%';
-		preElement.id = 'responseContent'
-		iframe.contentDocument.body.appendChild(preElement);
-	//	const form = document.getElementById('urlForm');
-	// 	form.addEventListener('submit', async function(event) {
-	// 		event.preventDefault();
-	// 		const action = form.action;
-	// 		const headers = new Headers();
-	// 		const token = form.token.value;
-	// 		if (token) {
-	// 			headers.append('Authorization', `Bearer ${token}`);
-	// 		}
-	// 		const formData = new FormData(form);
-	// 		formData.delete('token');
-	// 		try { 
-	// 		const response = await fetch(action, {
-	// 			method: 'POST',
-	// 			headers: headers,
-	// 			body: formData
-	// 		})
-	// 		if (response.ok) {
-	// 			const json = await response.json();
-	// 			const jsonStr = JSON.stringify(json, null, 2);
-	// 			preElement.textContent = jsonStr;
-	// 		} else {
-	// 			const text = await response.text();
-	// 			preElement.textContent = `Error ${response.status}:\n${text}`;
-	// 			throw new Error(`${response.status} - ${text}`);
-	// 		}
-	// 	} catch (error) {
-	// 		console.error(error);
-	// 	}
-	// });
-});
-	</script>
-<div>
-<iframe 
-	id="data"
-	title="Scrape Results"
-	name="data-iframe"
-	class="data-iframe"
-	>
-</div>
 </body>
 </html>

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -4,6 +4,7 @@
 	<meta charset="utf-8" />
 	<title>scrape</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 	<style>
 		label {
 			display: block;
@@ -24,7 +25,9 @@
 </head>
 <body>
 <p>
-<form id="urlForm" action="/extract" method="POST" name="scrape" target="data-iframe">
+<form action="/extract" x-data="formHandler" @submit.prevent="handleSubmit">
+
+<!-- <form id="urlForm" action="/extract" method="POST" name="scrape" target="data-iframe" x-data="formHandler" @submit.prevent="handleSubmit"> -->
 <label for="url">Enter a URL:</label>
 <input type="submit" value="Hit It">
 <input type="url" name="url" id="url" value="https://" size="96" maxlength="200" pattern="https?://.*" required title="URL">
@@ -44,43 +47,87 @@ function updateFormAction() {
 }
 </script>
 <script type="text/javascript">
+	function formHandler() {
+		return {
+			async handleSubmit(event) {
+				const form = event.target;
+				const action = form.action;
+				const headers = new Headers();
+				const token = form.token.value;
+				if (token) {
+					headers.append('Authorization', `Bearer ${token}`);
+				}
+				const formData = new FormData(form);
+				formData.delete('token');
+				try { 
+					const response = await fetch(action, {
+						method: 'POST',
+						headers: headers,
+						body: formData
+					})
+					
+					if (response.ok) {
+						const json = await response.json();
+						const jsonStr = JSON.stringify(json, null, 2);
+						this.updateContent(jsonStr);
+					} else {
+						const text = await response.text();
+						this.updateContent(`Error ${response.status}:\n${text}`);
+						throw new Error(`${response.status} - ${text}`);
+					}
+				} catch (error) {
+					console.error(error);
+				}
+			},
+			updateContent(content) {
+				const iframe = document.getElementById('data');
+                const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
+				const preElement = iframeDoc.getElementById('responseContent');
+				preElement.textContent = content;
+			}
+		}
+	}
+</script>
+
+<script type="text/javascript">
 	document.addEventListener('DOMContentLoaded', function() {
 		const iframe = document.getElementById('data');
 		iframe.contentDocument.body.innerHTML = '';
 		const preElement = document.createElement('pre');
 		preElement.style.whiteSpace = 'pre-wrap';
 		preElement.style.width = '100%';
+		preElement.id = 'responseContent'
 		iframe.contentDocument.body.appendChild(preElement);
-		const form = document.getElementById('urlForm');
-		form.addEventListener('submit', async function(event) {
-			event.preventDefault();
-			const action = form.action;
-			const headers = new Headers();
-			const token = form.token.value;
-			if (token) {
-				headers.append('Authorization', `Bearer ${token}`);
-			}
-			const formData = new FormData(form);
-			formData.delete('token');
-			try { 
-			const response = await fetch(action, {
-				method: 'POST',
-				headers: headers,
-				body: formData
-			})
-			if (response.ok) {
-				const json = await response.json();
-				const jsonStr = JSON.stringify(json, null, 2);
-				preElement.textContent = jsonStr;
-			} else {
-				const text = await response.text();
-				preElement.textContent = `Error ${response.status}:\n${text}`;
-				throw new Error(`${response.status} - ${text}`);
-			}
-		} catch (error) {
-			console.error(error);
-		}
-	});
+	//	const form = document.getElementById('urlForm');
+	// 	form.addEventListener('submit', async function(event) {
+	// 		event.preventDefault();
+	// 		const action = form.action;
+	// 		const headers = new Headers();
+	// 		const token = form.token.value;
+	// 		if (token) {
+	// 			headers.append('Authorization', `Bearer ${token}`);
+	// 		}
+	// 		const formData = new FormData(form);
+	// 		formData.delete('token');
+	// 		try { 
+	// 		const response = await fetch(action, {
+	// 			method: 'POST',
+	// 			headers: headers,
+	// 			body: formData
+	// 		})
+	// 		if (response.ok) {
+	// 			const json = await response.json();
+	// 			const jsonStr = JSON.stringify(json, null, 2);
+	// 			preElement.textContent = jsonStr;
+	// 		} else {
+	// 			const text = await response.text();
+	// 			preElement.textContent = `Error ${response.status}:\n${text}`;
+	// 			throw new Error(`${response.status} - ${text}`);
+	// 		}
+	// 	} catch (error) {
+	// 		console.error(error);
+	// 	}
+	// });
 });
 	</script>
 <div>

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -6,6 +6,37 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 	<style>
+		body, html {
+			margin: 0;
+			padding: 0;
+			height: 100vh;
+		}
+		.page-container {
+			display: flex;
+			flex-direction: column;
+			gap: 0.6rem;
+			box-sizing: border-box;
+			height: 100%;
+			padding: 0.6rem;
+		}
+		.controls-container {
+			background-color: #fff;
+			box-sizing: border-box;
+		}
+		.response-container {
+			width: 100%;
+			min-width: 768px;
+			flex: 1;
+			overflow: auto;
+			border: 0.1rem inset #ccc;
+			padding-block: 0.2rem;
+			padding-inline: 0.4rem;
+			box-sizing: border-box;
+		}
+		pre {
+			white-space: pre-wrap;
+			width: 100%;
+		}
 		label {
 			display: block;
 			font: 1rem 'Verdana'
@@ -14,24 +45,12 @@
 		label {
   			margin: 0.2rem 0;
 		}
-		pre {
-			white-space: pre-wrap;
-			width: 100%;
-		}
-		.response-container {
-			width: 100%;
-			min-width: 768px;
-			height: calc(100vh - 108px);
-			overflow: auto;
-			border: 0.1rem inset #ccc;
-			padding-block: 0.0rem;
-			padding-inline: 0.4rem;
-			box-sizing: border-box;			
-		}
+		
 	</style>
 </head>
 <body>
-<p>
+<div class="page-container">
+<div class="controls-container">
 <form x-data="formHandler" @submit.prevent="handleSubmit">
 <label for="url">Enter a URL:</label>
 <input type="submit" value="Hit It">
@@ -41,14 +60,15 @@
 	<option value="/extract/headless">Headless</option>
 	<option value="/feed">Feed</option>
 </select>
-<input type="hidden" name="token" value="{{AuthToken}}">
+<label for="token">Token:</label>
+<input type="text" name="token" size="101" maxlength="255" value="{{AuthToken}}" placeholder="Enter your access token">
 <input type="hidden" name="pp" value="1">
 </form>
-</p>
+</div><!-- controls-container -->
 <div class="response-container">
 	<pre x-ref="responseContent" id="responseContent"></pre>
 </div> 
-
+</div><!-- page-container -->
 <script type="text/javascript">
 	function formHandler() {
 		return {


### PR DESCRIPTION
This PR makes some organizational changes to the test console preceding disabling open access to the test console via a short-lived token and requiring users to enter a token. No functional changes in this release, just tweaking the html/js/css.

Main changes here: 
- Remove the iframe that was previously the response target and replace it with a div
- Update the HTML/CSS with a more coherent box model
- Incorporate AlpineJS and bind the form submission to the Alpine lifecycle (and evaluate and learn Alpine)

## Steps to Test

Again, no functional changes in this release, so it should operate exactly as https://stage.scrape.mozsoc-ml.nonprod.dataservices.mozgcp.net with some extremely minor visual changes.

### Building this PR

- Check out the branch

#### Without Go on your machine

- In the branch root: 
  - `make docker-build`
  - `make docker-run`

#### With Go 1.22.x on your machine

- In the branch root: 
  - `make`
  - `./build/scrape-server`

### Testing this PR

  - Point your browser to `http://127.0.0.1:8080`
  - Enter a url in the `Enter a URL` text field (like `https://arstechnica.com/gadgets/2024/07/arduinos-plug-and-make-kit-lets-your-hacking-imagination-run-wild-sans-solder/`)
  - Click "Hit It"
  - You should see metadata from the web page in the big text area
  - Using the same URL, try the `Headless` and `Feed` options from the pulldown. You should see errors in the big text area.
  - (For `Feed`, if you enter a valid RSS feed you should get results. `Headless` will work on mozgcp.net, but not in the local build you just made)
  
### References and Decisions
- In general, keeping the html simple and self-contained here is more important than download size/performance at this time. Hence everything is inline right now. 
- For more info about AlpineJS see [here](https://alpinejs.dev/). Moving forward, this view will get more interactive, so I'm evaluating Alpine as a lightweight tool to use for these cases. 
