### PR TITLE
Add token entry/storage functionality to test console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 MODULE_NAME := scrape
 ifneq ($(shell command -v go >/dev/null 2>&1 && echo yes),)
     MODULE_NAME := $(shell go list -m)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-MODULE_NAME := $(shell go list -m)
+
+MODULE_NAME := scrape
+ifneq ($(shell command -v go >/dev/null 2>&1 && echo yes),)
+    MODULE_NAME := $(shell go list -m)
+endif
 DOCKER_IMAGE_NAME := ${shell basename ${MODULE_NAME}}-bookworm-slim
 CWD := $(shell pwd)
 BUILD_DIR := build

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -23,9 +23,8 @@
 			font-family: Verdana, Arial, Helvetica, sans-serif;
 			font-size: 1.0rem;
 		}
-		input,
-		label {
-  			margin: 0.2rem 0;
+		input {
+  			padding-bottom: 0.1rem;
 		}
 		.page-container {
 			display: flex;
@@ -36,31 +35,36 @@
 		}
 		.controls-container {
 			width: 100%;
+			background-color: #ffffff;
+			border: 1px solid #414141;
+			padding: 0.6rem;
 		}
 		.controls-container form {
-			/* background-color: #ccc; */
 			display: flex;
 			flex-direction: column;
-			align-items: stretch;
 		}
-		.form-container {
+		.controls-container label {
+			padding-bottom: 0.2rem;
+		}
+		.url-entry-container {
 			display: flex;
 			align-items: center;
 			gap: 0.3rem;
 		}
-		.controls-container input[type="url"] {
+		.url-entry-container input[type="url"] {
 			flex-grow: 1;
-			/* margin-right: 0.6rem; */
+		}
+		.url-entry-container input[type="submit"] {
+			padding-inline: 0.6rem;
 		}
 		.token-container {
+			background-color: #ffffff;
+			border: 1px solid #414141;
+			padding: 0.6rem;
 			display: flex;
 			flex-direction: column;
 			gap: 0.6rem;
 		}
-		/* .token-header {
-            background-color: #f0f0f0; */
-            /* padding: 20px;
-        } */
 		.token-controls {
 			display: flex;
 			justify-content: space-between;
@@ -81,7 +85,6 @@
 			display: flex;
 			flex-direction: column;
 			align-items: flex-start;
-			/* justify-content: flex-start; */
 		}
 		.token-info button {
 			width: 100%;
@@ -104,7 +107,6 @@
 		}
 		.response-container {
 			width: 100%;
-			min-width: 768px;
 			flex: 1;
 			overflow: auto;
 			border: 0.1rem inset #ccc;
@@ -119,7 +121,7 @@
 <div class="controls-container">
 	<form x-data="formHandler" @submit.prevent="handleSubmit">
 	<label for="url">Enter a URL:</label>
-	<div class="form-container">
+	<div class="url-entry-container">
 		<select title="URL Type" x-model="formAction">
 			<option value="/extract">Page</option>
 			<option value="/extract/headless">Headless</option>
@@ -131,6 +133,7 @@
 	</div>	
 	</form>
 </div><!-- controls-container -->
+<!-- {{if AuthEnabled}}  -->
 <div class="token-container" x-data="{ isCollapsed: true}">
 	<div class="token-header">
 		<button x-on:click="isCollapsed = !isCollapsed">Enter Token</button>
@@ -145,6 +148,7 @@
 		</div>
 	</div>
 </div>
+<!-- {{end}} -->
 <div class="response-container">
 	<pre x-ref="responseContent" id="responseContent"></pre>
 </div> 

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -2,260 +2,260 @@
 <html lang="en">
 
 <head>
-	<meta charset="utf-8" />
-	<title>scrape</title>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
-	<style>
-		body,
-		html {
-			margin: 0;
-			padding: 0;
-			height: 100vh;
-		}
+  <meta charset="utf-8" />
+  <title>scrape</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <style>
+    body,
+    html {
+      margin: 0;
+      padding: 0;
+      height: 100vh;
+    }
 
-		div {
-			box-sizing: border-box;
-		}
+    div {
+      box-sizing: border-box;
+    }
 
-		pre {
-			white-space: pre-wrap;
-			width: 100%;
-		}
+    pre {
+      white-space: pre-wrap;
+      width: 100%;
+    }
 
-		label {
-			display: block;
-			font-family: Verdana, Arial, Helvetica, sans-serif;
-			font-size: 1.0rem;
-		}
+    label {
+      display: block;
+      font-family: Verdana, Arial, Helvetica, sans-serif;
+      font-size: 1.0rem;
+    }
 
-		input {
-			padding-bottom: 0.1rem;
-		}
+    input {
+      padding-bottom: 0.1rem;
+    }
 
-		.page-container {
-			display: flex;
-			flex-direction: column;
-			gap: 0.6rem;
-			height: 100%;
-			padding: 0.6rem;
-		}
+    .page-container {
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+      height: 100%;
+      padding: 0.6rem;
+    }
 
-		.controls-container {
-			width: 100%;
-			background-color: #ffffff;
-			border: 1px solid #414141;
-			padding: 0.6rem;
-		}
+    .controls-container {
+      width: 100%;
+      background-color: #ffffff;
+      border: 1px solid #414141;
+      padding: 0.6rem;
+    }
 
-		.controls-container form {
-			display: flex;
-			flex-direction: column;
-		}
+    .controls-container form {
+      display: flex;
+      flex-direction: column;
+    }
 
-		.controls-container label {
-			padding-bottom: 0.3rem;
-		}
+    .controls-container label {
+      padding-bottom: 0.3rem;
+    }
 
-		.url-entry-container {
-			display: flex;
-			align-items: center;
-			gap: 0.3rem;
-		}
+    .url-entry-container {
+      display: flex;
+      align-items: center;
+      gap: 0.3rem;
+    }
 
-		.url-entry-container input[type="url"] {
-			flex-grow: 1;
-		}
+    .url-entry-container input[type="url"] {
+      flex-grow: 1;
+    }
 
-		.url-entry-container input[type="submit"] {
-			padding-inline: 0.6rem;
-		}
+    .url-entry-container input[type="submit"] {
+      padding-inline: 0.6rem;
+    }
 
-		.token-container {
-			background-color: #ffffff;
-			border: 1px solid #414141;
-			padding: 0.6rem;
-			display: flex;
-			flex-direction: column;
-			gap: 0.6rem;
-		}
+    .token-container {
+      background-color: #ffffff;
+      border: 1px solid #414141;
+      padding: 0.6rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+    }
 
-		.token-header {
-			display: flex;
-			justify-content: start;
-			align-items: center;
-			gap: 0.3rem;
-		}
+    .token-header {
+      display: flex;
+      justify-content: start;
+      align-items: center;
+      gap: 0.3rem;
+    }
 
-		.token-header a {
-			font-size: 1.0rem;
-			font-family: Verdana, Arial, Helvetica, sans-serif;
-			text-decoration: none;
-			margin-bottom: 1px;
-			line-height: 0.8rem;
-			color: #000000;
-		}
+    .token-header a {
+      font-size: 1.0rem;
+      font-family: Verdana, Arial, Helvetica, sans-serif;
+      text-decoration: none;
+      margin-bottom: 1px;
+      line-height: 0.8rem;
+      color: #000000;
+    }
 
-		.token-toggle {
-			font-size: 1.6rem;
-			font-weight: bold;
-			line-height: 0.8rem;
-			cursor: pointer;
-		}
+    .token-toggle {
+      font-size: 1.6rem;
+      font-weight: bold;
+      line-height: 0.8rem;
+      cursor: pointer;
+    }
 
-		.token-controls {
-			display: flex;
-			justify-content: space-between;
-		}
+    .token-controls {
+      display: flex;
+      justify-content: space-between;
+    }
 
-		.token-entry {
-			flex-grow: 1;
-			margin-right: 0.6rem;
-		}
+    .token-entry {
+      flex-grow: 1;
+      margin-right: 0.6rem;
+    }
 
-		.token-textarea {
-			box-sizing: border-box;
-			resize: vertical;
-			width: 100%;
-			height: 100%;
-		}
+    .token-textarea {
+      box-sizing: border-box;
+      resize: vertical;
+      width: 100%;
+      height: 100%;
+    }
 
-		.token-info {
-			white-space: nowrap;
-			display: flex;
-			flex-direction: column;
-			align-items: flex-start;
-		}
+    .token-info {
+      white-space: nowrap;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
 
-		.token-info button {
-			width: 100%;
-			padding: 0.1rem 1.0rem;
-			cursor: pointer;
-		}
+    .token-info button {
+      width: 100%;
+      padding: 0.1rem 1.0rem;
+      cursor: pointer;
+    }
 
-		.token-info button:first-child {
-			margin-top: 0.1rem;
-			margin-bottom: 0.4rem;
-		}
+    .token-info button:first-child {
+      margin-top: 0.1rem;
+      margin-bottom: 0.4rem;
+    }
 
-		.response-container {
-			width: 100%;
-			flex: 1;
-			overflow: auto;
-			border: 0.1rem inset #ccc;
-			padding-block: 0.2rem;
-			padding-inline: 0.4rem;
-			user-select: text;
-		}
-	</style>
+    .response-container {
+      width: 100%;
+      flex: 1;
+      overflow: auto;
+      border: 0.1rem inset #ccc;
+      padding-block: 0.2rem;
+      padding-inline: 0.4rem;
+      user-select: text;
+    }
+  </style>
 </head>
 
 <body>
-	<div class="page-container">
-		<div class="controls-container">
-			<form x-data="formHandler" @submit.prevent="handleSubmit">
-				<label for="url">Enter a URL:</label>
-				<div class="url-entry-container">
-					<select title="URL Type" x-model="formAction">
-						<option value="/extract">Page</option>
-						<option value="/extract/headless">Headless</option>
-						<option value="/feed">Feed</option>
-					</select>
-					<input type="url" name="url" id="url" value="https://" maxlength="200" pattern="https?://.*" required
-						title="URL">
-					<input type="submit" value="Hit It">
-					<input type="hidden" name="pp" value="1">
-				</div>
-			</form>
-		</div><!-- controls-container -->
-		<!-- {{if AuthEnabled}}  -->
-		<div class="token-container" x-data="tokenHandler()">
-			<div class="token-header">
-				<span @click="isCollapsed = !isCollapsed" class="token-toggle">
-					<span x-show="isCollapsed">&#x002B;</span>
-					<span x-show="!isCollapsed">&#x2212;</span>
-				</span>
-				<a href="#" class="toggle-link" @click.prevent="isCollapsed = !isCollapsed">Enter Token</a>
-			</div>
-			<div x-show="!isCollapsed" class="token-controls" x-transition.scale>
-				<div class="token-entry">
-					<textarea x-model="authToken" class="token-textarea" id="token" rows="2"
-						placeholder="Enter your access token here"></textarea>
-				</div>
-				<div class="token-info">
-					<button @click="saveToken()">Save Token</button>
-					<button @click="clearToken()">Clear Token</button>
-				</div>
-			</div>
-		</div>
-		<!-- {{end}} -->
-		<div class="response-container">
-			<pre x-ref="responseContent" id="responseContent"></pre>
-		</div>
-	</div><!-- page-container -->
-	<script type="text/javascript">
-		function formHandler() {
-			return {
-				formAction: '/extract',
-				async handleSubmit(event) {
-					const form = event.target;
-					const headers = new Headers();
-					const token = document.getElementById('token')?.value ?? '';
-					if (token) {
-						headers.append('Authorization', `Bearer ${token}`);
-					}
-					const formData = new FormData(form);
-					try {
-						const response = await fetch(this.formAction, {
-							method: 'POST',
-							headers: headers,
-							body: formData
-						})
+  <div class="page-container">
+    <div class="controls-container">
+      <form x-data="formHandler" @submit.prevent="handleSubmit">
+        <label for="url">Enter a URL:</label>
+        <div class="url-entry-container">
+          <select title="URL Type" x-model="formAction">
+            <option value="/extract">Page</option>
+            <option value="/extract/headless">Headless</option>
+            <option value="/feed">Feed</option>
+          </select>
+          <input type="url" name="url" id="url" value="https://" maxlength="200" pattern="https?://.*" required
+            title="URL">
+          <input type="submit" value="Hit It">
+          <input type="hidden" name="pp" value="1">
+        </div>
+      </form>
+    </div><!-- controls-container -->
+    <!-- {{if AuthEnabled}}  -->
+    <div class="token-container" x-data="tokenHandler()">
+      <div class="token-header">
+        <span @click="isCollapsed = !isCollapsed" class="token-toggle">
+          <span x-show="isCollapsed">&#x002B;</span>
+          <span x-show="!isCollapsed">&#x2212;</span>
+        </span>
+        <a href="#" class="toggle-link" @click.prevent="isCollapsed = !isCollapsed">Enter Token</a>
+      </div>
+      <div x-show="!isCollapsed" class="token-controls" x-transition.scale>
+        <div class="token-entry">
+          <textarea x-model="authToken" class="token-textarea" id="token" rows="2"
+            placeholder="Enter your access token here"></textarea>
+        </div>
+        <div class="token-info">
+          <button @click="saveToken()">Save Token</button>
+          <button @click="clearToken()">Clear Token</button>
+        </div>
+      </div>
+    </div>
+    <!-- {{end}} -->
+    <div class="response-container">
+      <pre x-ref="responseContent" id="responseContent"></pre>
+    </div>
+  </div><!-- page-container -->
+  <script type="text/javascript">
+    function formHandler() {
+      return {
+        formAction: '/extract',
+        async handleSubmit(event) {
+          const form = event.target;
+          const headers = new Headers();
+          const token = document.getElementById('token')?.value ?? '';
+          if (token) {
+            headers.append('Authorization', `Bearer ${token}`);
+          }
+          const formData = new FormData(form);
+          try {
+            const response = await fetch(this.formAction, {
+              method: 'POST',
+              headers: headers,
+              body: formData
+            })
 
-						if (response.ok) {
-							const json = await response.json();
-							const jsonStr = JSON.stringify(json, null, 2);
-							this.updateContent(jsonStr);
-						} else {
-							const text = await response.text();
-							this.updateContent(`Error ${response.status}:\n${text}`);
-							throw new Error(`${response.status} - ${text}`);
-						}
-					} catch (error) {
-						console.error(error);
-					}
-				},
-				updateContent(content) {
-					document.getElementById('responseContent').textContent = content;
-					// following should work but doesn't
-					// this.$refs.responseContent.textContent = content;
-				}
-			}
-		}
-	</script>
-	<script type="text/javascript">
-		function tokenHandler() {
-			return {
-				isCollapsed: true,
-				authToken: localStorage.getItem('scrapeToken') || '{{AuthToken}}',
-				async saveToken() {
-					try {
-						const token = document.getElementById('token').value;
-						if (token) {
-							localStorage.setItem('scrapeToken', token);
-							alert('Token saved');
-						}
-					} catch (e) {
-						console.error('Error saving token to local storage', e);
-					}
-				},
-				async clearToken() {
-					localStorage.removeItem('scrapeToken');
-					document.getElementById('token').value = '';
-				},
-			}
-		}
-	</script>
+            if (response.ok) {
+              const json = await response.json();
+              const jsonStr = JSON.stringify(json, null, 2);
+              this.updateContent(jsonStr);
+            } else {
+              const text = await response.text();
+              this.updateContent(`Error ${response.status}:\n${text}`);
+              throw new Error(`${response.status} - ${text}`);
+            }
+          } catch (error) {
+            console.error(error);
+          }
+        },
+        updateContent(content) {
+          document.getElementById('responseContent').textContent = content;
+          // following should work but doesn't
+          // this.$refs.responseContent.textContent = content;
+        }
+      }
+    }
+  </script>
+  <script type="text/javascript">
+    function tokenHandler() {
+      return {
+        isCollapsed: true,
+        authToken: localStorage.getItem('scrapeToken') || '{{AuthToken}}',
+        async saveToken() {
+          try {
+            const token = document.getElementById('token').value;
+            if (token) {
+              localStorage.setItem('scrapeToken', token);
+              alert('Token saved');
+            }
+          } catch (e) {
+            console.error('Error saving token to local storage', e);
+          }
+        },
+        async clearToken() {
+          localStorage.removeItem('scrapeToken');
+          document.getElementById('token').value = '';
+        },
+      }
+    }
+  </script>
 
 </body>
 

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -35,7 +35,22 @@
 			padding: 0.6rem;
 		}
 		.controls-container {
-			background-color: #fff;
+			width: 100%;
+		}
+		.controls-container form {
+			/* background-color: #ccc; */
+			display: flex;
+			flex-direction: column;
+			align-items: stretch;
+		}
+		.form-container {
+			display: flex;
+			align-items: center;
+			gap: 0.3rem;
+		}
+		.controls-container input[type="url"] {
+			flex-grow: 1;
+			/* margin-right: 0.6rem; */
 		}
 		.token-container {
 			display: flex;
@@ -104,14 +119,16 @@
 <div class="controls-container">
 	<form x-data="formHandler" @submit.prevent="handleSubmit">
 	<label for="url">Enter a URL:</label>
-	<select title="URL Type" x-model="formAction">
-		<option value="/extract">Page</option>
-		<option value="/extract/headless">Headless</option>
-		<option value="/feed">Feed</option>
-	</select>
-	<input type="url" name="url" id="url" value="https://" size="96" maxlength="200" pattern="https?://.*" required title="URL">
-	<input type="submit" value="Hit It">
-	<input type="hidden" name="pp" value="1">
+	<div class="form-container">
+		<select title="URL Type" x-model="formAction">
+			<option value="/extract">Page</option>
+			<option value="/extract/headless">Headless</option>
+			<option value="/feed">Feed</option>
+		</select>
+		<input type="url" name="url" id="url" value="https://" maxlength="200" pattern="https?://.*" required title="URL">
+		<input type="submit" value="Hit It">
+		<input type="hidden" name="pp" value="1">
+	</div>	
 	</form>
 </div><!-- controls-container -->
 <div class="token-container" x-data="{ isCollapsed: true}">

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -65,6 +65,26 @@
 			flex-direction: column;
 			gap: 0.6rem;
 		}
+		.token-header {
+			display: flex;
+			justify-content: start;
+			align-items: center;
+			gap: 0.3rem;
+		}
+		.token-header a {
+			font-size: 1.0rem;
+			font-family: Verdana, Arial, Helvetica, sans-serif;
+			text-decoration: none;
+			margin-bottom: 1px;
+			line-height: 0.8rem;
+			color: #000000;
+		}
+		.token-toggle {
+			font-size: 1.6rem;
+			font-weight: bold;
+			line-height: 0.8rem;
+			cursor: pointer;
+		}
 		.token-controls {
 			display: flex;
 			justify-content: space-between;
@@ -125,7 +145,11 @@
 <!-- {{if AuthEnabled}}  -->
 <div class="token-container" x-data="tokenHandler()">
 	<div class="token-header">
-		<button x-on:click="isCollapsed = !isCollapsed">Enter Token</button>
+		<span @click="isCollapsed = !isCollapsed" class="token-toggle">
+			<span x-show="isCollapsed">&#x002B;</span>
+            <span x-show="!isCollapsed">&#x2212;</span>
+		</span>
+		<a href="#" class="toggle-link" @click.prevent="isCollapsed = !isCollapsed">Enter Token</a>
 	</div>
 	<div x-show="!isCollapsed" class="token-controls" x-transition.scale>
 		<div class="token-entry">

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -173,7 +173,7 @@
 			async handleSubmit(event) {
 				const form = event.target;
 				const headers = new Headers();
-				const token = document.getElementById('token').value;
+				const token = document.getElementById('token')?.value ?? '';
 				if (token) {
 					headers.append('Authorization', `Bearer ${token}`);
 				}

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -44,7 +44,7 @@
 			flex-direction: column;
 		}
 		.controls-container label {
-			padding-bottom: 0.2rem;
+			padding-bottom: 0.3rem;
 		}
 		.url-entry-container {
 			display: flex;

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -171,6 +171,7 @@
     <!-- {{if AuthEnabled}}  -->
     <div class="token-container" x-data="tokenHandler()">
       <div class="token-header">
+        <!-- TODO: Convert <a> to button, link hover color/state of +/- and button -->
         <span @click="isCollapsed = !isCollapsed" class="token-toggle">
           <span x-show="isCollapsed">&#x002B;</span>
           <span x-show="!isCollapsed">&#x2212;</span>

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -32,6 +32,7 @@
 			padding-block: 0.2rem;
 			padding-inline: 0.4rem;
 			box-sizing: border-box;
+			user-select: text;
 		}
 		pre {
 			white-space: pre-wrap;
@@ -39,13 +40,13 @@
 		}
 		label {
 			display: block;
-			font: 1rem 'Verdana'
+			font-family: Verdana, Arial, Helvetica, sans-serif;
+			font-size: 1.0rem;
 		}
 		input,
 		label {
   			margin: 0.2rem 0;
 		}
-		
 	</style>
 </head>
 <body>
@@ -53,13 +54,13 @@
 <div class="controls-container">
 <form x-data="formHandler" @submit.prevent="handleSubmit">
 <label for="url">Enter a URL:</label>
-<input type="submit" value="Hit It">
-<input type="url" name="url" id="url" value="https://" size="96" maxlength="200" pattern="https?://.*" required title="URL">
 <select title="URL Type" x-model="formAction">
 	<option value="/extract">Page</option>
 	<option value="/extract/headless">Headless</option>
 	<option value="/feed">Feed</option>
 </select>
+<input type="url" name="url" id="url" value="https://" size="96" maxlength="200" pattern="https?://.*" required title="URL">
+<input type="submit" value="Hit It">
 <!-- <label for="token">Token:</label> -->
 <input type="hidden" name="token" size="101" maxlength="255" value="{{AuthToken}}" placeholder="Enter your access token">
 <input type="hidden" name="pp" value="1">

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -202,6 +202,7 @@
 					const token = document.getElementById('token').value;
 					if (token) {
 						localStorage.setItem('scrapeToken', token);
+						alert('Token saved');
 					}
 				} catch (e) {
 					console.error('Error saving token to local storage', e);

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -1,31 +1,38 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
 	<meta charset="utf-8" />
 	<title>scrape</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 	<style>
-		body, html {
+		body,
+		html {
 			margin: 0;
 			padding: 0;
 			height: 100vh;
 		}
+
 		div {
 			box-sizing: border-box;
 		}
+
 		pre {
 			white-space: pre-wrap;
 			width: 100%;
 		}
+
 		label {
 			display: block;
 			font-family: Verdana, Arial, Helvetica, sans-serif;
 			font-size: 1.0rem;
 		}
+
 		input {
-  			padding-bottom: 0.1rem;
+			padding-bottom: 0.1rem;
 		}
+
 		.page-container {
 			display: flex;
 			flex-direction: column;
@@ -33,30 +40,37 @@
 			height: 100%;
 			padding: 0.6rem;
 		}
+
 		.controls-container {
 			width: 100%;
 			background-color: #ffffff;
 			border: 1px solid #414141;
 			padding: 0.6rem;
 		}
+
 		.controls-container form {
 			display: flex;
 			flex-direction: column;
 		}
+
 		.controls-container label {
 			padding-bottom: 0.3rem;
 		}
+
 		.url-entry-container {
 			display: flex;
 			align-items: center;
 			gap: 0.3rem;
 		}
+
 		.url-entry-container input[type="url"] {
 			flex-grow: 1;
 		}
+
 		.url-entry-container input[type="submit"] {
 			padding-inline: 0.6rem;
 		}
+
 		.token-container {
 			background-color: #ffffff;
 			border: 1px solid #414141;
@@ -65,12 +79,14 @@
 			flex-direction: column;
 			gap: 0.6rem;
 		}
+
 		.token-header {
 			display: flex;
 			justify-content: start;
 			align-items: center;
 			gap: 0.3rem;
 		}
+
 		.token-header a {
 			font-size: 1.0rem;
 			font-family: Verdana, Arial, Helvetica, sans-serif;
@@ -79,41 +95,49 @@
 			line-height: 0.8rem;
 			color: #000000;
 		}
+
 		.token-toggle {
 			font-size: 1.6rem;
 			font-weight: bold;
 			line-height: 0.8rem;
 			cursor: pointer;
 		}
+
 		.token-controls {
 			display: flex;
 			justify-content: space-between;
 		}
+
 		.token-entry {
 			flex-grow: 1;
 			margin-right: 0.6rem;
 		}
+
 		.token-textarea {
 			box-sizing: border-box;
 			resize: vertical;
 			width: 100%;
 			height: 100%;
 		}
+
 		.token-info {
 			white-space: nowrap;
 			display: flex;
 			flex-direction: column;
 			align-items: flex-start;
 		}
+
 		.token-info button {
 			width: 100%;
-			padding: 0.1rem 1.0rem; 
+			padding: 0.1rem 1.0rem;
 			cursor: pointer;
 		}
+
 		.token-info button:first-child {
 			margin-top: 0.1rem;
 			margin-bottom: 0.4rem;
 		}
+
 		.response-container {
 			width: 100%;
 			flex: 1;
@@ -125,110 +149,114 @@
 		}
 	</style>
 </head>
+
 <body>
-<div class="page-container">
-<div class="controls-container">
-	<form x-data="formHandler" @submit.prevent="handleSubmit">
-	<label for="url">Enter a URL:</label>
-	<div class="url-entry-container">
-		<select title="URL Type" x-model="formAction">
-			<option value="/extract">Page</option>
-			<option value="/extract/headless">Headless</option>
-			<option value="/feed">Feed</option>
-		</select>
-		<input type="url" name="url" id="url" value="https://" maxlength="200" pattern="https?://.*" required title="URL">
-		<input type="submit" value="Hit It">
-		<input type="hidden" name="pp" value="1">
-	</div>	
-	</form>
-</div><!-- controls-container -->
-<!-- {{if AuthEnabled}}  -->
-<div class="token-container" x-data="tokenHandler()">
-	<div class="token-header">
-		<span @click="isCollapsed = !isCollapsed" class="token-toggle">
-			<span x-show="isCollapsed">&#x002B;</span>
-            <span x-show="!isCollapsed">&#x2212;</span>
-		</span>
-		<a href="#" class="toggle-link" @click.prevent="isCollapsed = !isCollapsed">Enter Token</a>
-	</div>
-	<div x-show="!isCollapsed" class="token-controls" x-transition.scale>
-		<div class="token-entry">
-			<textarea x-model="authToken" class="token-textarea" id="token" rows="2" placeholder="Enter your access token here"></textarea>
+	<div class="page-container">
+		<div class="controls-container">
+			<form x-data="formHandler" @submit.prevent="handleSubmit">
+				<label for="url">Enter a URL:</label>
+				<div class="url-entry-container">
+					<select title="URL Type" x-model="formAction">
+						<option value="/extract">Page</option>
+						<option value="/extract/headless">Headless</option>
+						<option value="/feed">Feed</option>
+					</select>
+					<input type="url" name="url" id="url" value="https://" maxlength="200" pattern="https?://.*" required
+						title="URL">
+					<input type="submit" value="Hit It">
+					<input type="hidden" name="pp" value="1">
+				</div>
+			</form>
+		</div><!-- controls-container -->
+		<!-- {{if AuthEnabled}}  -->
+		<div class="token-container" x-data="tokenHandler()">
+			<div class="token-header">
+				<span @click="isCollapsed = !isCollapsed" class="token-toggle">
+					<span x-show="isCollapsed">&#x002B;</span>
+					<span x-show="!isCollapsed">&#x2212;</span>
+				</span>
+				<a href="#" class="toggle-link" @click.prevent="isCollapsed = !isCollapsed">Enter Token</a>
+			</div>
+			<div x-show="!isCollapsed" class="token-controls" x-transition.scale>
+				<div class="token-entry">
+					<textarea x-model="authToken" class="token-textarea" id="token" rows="2"
+						placeholder="Enter your access token here"></textarea>
+				</div>
+				<div class="token-info">
+					<button @click="saveToken()">Save Token</button>
+					<button @click="clearToken()">Clear Token</button>
+				</div>
+			</div>
 		</div>
-		<div class="token-info">
-			<button @click="saveToken()">Save Token</button>
-            <button @click="clearToken()">Clear Token</button>
+		<!-- {{end}} -->
+		<div class="response-container">
+			<pre x-ref="responseContent" id="responseContent"></pre>
 		</div>
-	</div>
-</div>
-<!-- {{end}} -->
-<div class="response-container">
-	<pre x-ref="responseContent" id="responseContent"></pre>
-</div> 
-</div><!-- page-container -->
-<script type="text/javascript">
-	function formHandler() {
-		return {
-			formAction: '/extract',
-			async handleSubmit(event) {
-				const form = event.target;
-				const headers = new Headers();
-				const token = document.getElementById('token')?.value ?? '';
-				if (token) {
-					headers.append('Authorization', `Bearer ${token}`);
-				}
-				const formData = new FormData(form);
-				try { 
-					const response = await fetch(this.formAction, {
-						method: 'POST',
-						headers: headers,
-						body: formData
-					})
-					
-					if (response.ok) {
-						const json = await response.json();
-						const jsonStr = JSON.stringify(json, null, 2);
-						this.updateContent(jsonStr);
-					} else {
-						const text = await response.text();
-						this.updateContent(`Error ${response.status}:\n${text}`);
-						throw new Error(`${response.status} - ${text}`);
+	</div><!-- page-container -->
+	<script type="text/javascript">
+		function formHandler() {
+			return {
+				formAction: '/extract',
+				async handleSubmit(event) {
+					const form = event.target;
+					const headers = new Headers();
+					const token = document.getElementById('token')?.value ?? '';
+					if (token) {
+						headers.append('Authorization', `Bearer ${token}`);
 					}
-				} catch (error) {
-					console.error(error);
+					const formData = new FormData(form);
+					try {
+						const response = await fetch(this.formAction, {
+							method: 'POST',
+							headers: headers,
+							body: formData
+						})
+
+						if (response.ok) {
+							const json = await response.json();
+							const jsonStr = JSON.stringify(json, null, 2);
+							this.updateContent(jsonStr);
+						} else {
+							const text = await response.text();
+							this.updateContent(`Error ${response.status}:\n${text}`);
+							throw new Error(`${response.status} - ${text}`);
+						}
+					} catch (error) {
+						console.error(error);
+					}
+				},
+				updateContent(content) {
+					document.getElementById('responseContent').textContent = content;
+					// following should work but doesn't
+					// this.$refs.responseContent.textContent = content;
 				}
-			},
-			updateContent(content) {
-				document.getElementById('responseContent').textContent = content;
-				// following should work but doesn't
-				// this.$refs.responseContent.textContent = content;
 			}
 		}
-	}
-</script>
-<script type="text/javascript">
-	function tokenHandler() {
-		return {
-			isCollapsed: true,
-			authToken: localStorage.getItem('scrapeToken') || '{{AuthToken}}',
-			async saveToken() {
-				try {
-					const token = document.getElementById('token').value;
-					if (token) {
-						localStorage.setItem('scrapeToken', token);
-						alert('Token saved');
+	</script>
+	<script type="text/javascript">
+		function tokenHandler() {
+			return {
+				isCollapsed: true,
+				authToken: localStorage.getItem('scrapeToken') || '{{AuthToken}}',
+				async saveToken() {
+					try {
+						const token = document.getElementById('token').value;
+						if (token) {
+							localStorage.setItem('scrapeToken', token);
+							alert('Token saved');
+						}
+					} catch (e) {
+						console.error('Error saving token to local storage', e);
 					}
-				} catch (e) {
-					console.error('Error saving token to local storage', e);
-				}
-			},
-			async clearToken() {
-				localStorage.removeItem('scrapeToken');
-				document.getElementById('token').value = '';
-			},
+				},
+				async clearToken() {
+					localStorage.removeItem('scrapeToken');
+					document.getElementById('token').value = '';
+				},
+			}
 		}
-	}
-</script>
+	</script>
 
 </body>
+
 </html>

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -11,28 +11,8 @@
 			padding: 0;
 			height: 100vh;
 		}
-		.page-container {
-			display: flex;
-			flex-direction: column;
-			gap: 0.6rem;
+		div {
 			box-sizing: border-box;
-			height: 100%;
-			padding: 0.6rem;
-		}
-		.controls-container {
-			background-color: #fff;
-			box-sizing: border-box;
-		}
-		.response-container {
-			width: 100%;
-			min-width: 768px;
-			flex: 1;
-			overflow: auto;
-			border: 0.1rem inset #ccc;
-			padding-block: 0.2rem;
-			padding-inline: 0.4rem;
-			box-sizing: border-box;
-			user-select: text;
 		}
 		pre {
 			white-space: pre-wrap;
@@ -47,25 +27,100 @@
 		label {
   			margin: 0.2rem 0;
 		}
+		.page-container {
+			display: flex;
+			flex-direction: column;
+			gap: 0.6rem;
+			height: 100%;
+			padding: 0.6rem;
+		}
+		.controls-container {
+			background-color: #fff;
+		}
+		.token-container {
+			display: flex;
+			flex-direction: column;
+			gap: 0.6rem;
+		}
+		/* .token-header {
+            background-color: #f0f0f0; */
+            /* padding: 20px;
+        } */
+		.token-controls {
+			display: flex;
+			justify-content: space-between;
+			/* background-color: #3d997d; */
+		}
+		.token-entry {
+			flex-grow: 1;
+			min-width: 400px;
+			margin-right: 0.6rem;
+			/* border: 1px solid #000; */
+			color: #b9e29c;
+		}
+		.token-textarea {
+			/* border: 0.1rem inset #ccc; */
+			box-sizing: border-box;
+			resize: vertical;
+			width: 100%;
+		}
+		.token-info {
+			white-space: nowrap;
+			display: flex;
+			align-items: flex-start;
+			justify-content: flex-start;
+		}
+		.token-info label {
+			display: block;
+			margin-inline: 0.2rem;
+			margin-block: 0;
+			font-family: Verdana, Arial, Helvetica, sans-serif;
+			font-size: 0.8rem;
+		}
+		.token-info input[type="checkbox"] {
+			vertical-align: middle;
+		}
+		.response-container {
+			width: 100%;
+			min-width: 768px;
+			flex: 1;
+			overflow: auto;
+			border: 0.1rem inset #ccc;
+			padding-block: 0.2rem;
+			padding-inline: 0.4rem;
+			user-select: text;
+		}
 	</style>
 </head>
 <body>
 <div class="page-container">
 <div class="controls-container">
-<form x-data="formHandler" @submit.prevent="handleSubmit">
-<label for="url">Enter a URL:</label>
-<select title="URL Type" x-model="formAction">
-	<option value="/extract">Page</option>
-	<option value="/extract/headless">Headless</option>
-	<option value="/feed">Feed</option>
-</select>
-<input type="url" name="url" id="url" value="https://" size="96" maxlength="200" pattern="https?://.*" required title="URL">
-<input type="submit" value="Hit It">
-<!-- <label for="token">Token:</label> -->
-<input type="hidden" name="token" size="101" maxlength="255" value="{{AuthToken}}" placeholder="Enter your access token">
-<input type="hidden" name="pp" value="1">
-</form>
+	<form x-data="formHandler" @submit.prevent="handleSubmit">
+	<label for="url">Enter a URL:</label>
+	<select title="URL Type" x-model="formAction">
+		<option value="/extract">Page</option>
+		<option value="/extract/headless">Headless</option>
+		<option value="/feed">Feed</option>
+	</select>
+	<input type="url" name="url" id="url" value="https://" size="96" maxlength="200" pattern="https?://.*" required title="URL">
+	<input type="submit" value="Hit It">
+	<input type="hidden" name="pp" value="1">
+	</form>
 </div><!-- controls-container -->
+<div class="token-container" x-data="{ isCollapsed: true}">
+	<div class="token-header">
+		<button x-on:click="isCollapsed = !isCollapsed">Enter Token</button>
+	</div>
+	<div x-show="!isCollapsed" class="token-controls" x-transition.scale>
+		<div class="token-entry">
+			<textarea class="token-textarea" id="token" rows="2" placeholder="Enter your access token here">{{AuthToken}}</textarea>
+		</div>
+		<div class="token-info">
+			<input type="checkbox" id="saveToken">
+            <label for="saveToken">Save this token</label>
+		</div>
+	</div>
+</div>
 <div class="response-container">
 	<pre x-ref="responseContent" id="responseContent"></pre>
 </div> 
@@ -77,12 +132,11 @@
 			async handleSubmit(event) {
 				const form = event.target;
 				const headers = new Headers();
-				const token = form.token.value;
+				const token = document.getElementById('token').value;
 				if (token) {
 					headers.append('Authorization', `Bearer ${token}`);
 				}
 				const formData = new FormData(form);
-				formData.delete('token');
 				try { 
 					const response = await fetch(this.formAction, {
 						method: 'POST',

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -71,7 +71,6 @@
 		}
 		.token-entry {
 			flex-grow: 1;
-			min-width: 400px;
 			margin-right: 0.6rem;
 		}
 		.token-textarea {
@@ -134,17 +133,17 @@
 	</form>
 </div><!-- controls-container -->
 <!-- {{if AuthEnabled}}  -->
-<div class="token-container" x-data="{ isCollapsed: true}">
+<div class="token-container" x-data="tokenHandler()">
 	<div class="token-header">
 		<button x-on:click="isCollapsed = !isCollapsed">Enter Token</button>
 	</div>
 	<div x-show="!isCollapsed" class="token-controls" x-transition.scale>
 		<div class="token-entry">
-			<textarea class="token-textarea" id="token" rows="2" placeholder="Enter your access token here">{{AuthToken}}</textarea>
+			<textarea x-model="authToken" class="token-textarea" id="token" rows="2" placeholder="Enter your access token here"></textarea>
 		</div>
 		<div class="token-info">
-			<button class="button">Save Token</button>
-            <button class="button">Clear Token</button>
+			<button @click="saveToken()">Save Token</button>
+            <button @click="clearToken()">Clear Token</button>
 		</div>
 	</div>
 </div>
@@ -190,6 +189,28 @@
 				// following should work but doesn't
 				// this.$refs.responseContent.textContent = content;
 			}
+		}
+	}
+</script>
+<script type="text/javascript">
+	function tokenHandler() {
+		return {
+			isCollapsed: true,
+			authToken: localStorage.getItem('scrapeToken') || '{{AuthToken}}',
+			async saveToken() {
+				try {
+					const token = document.getElementById('token').value;
+					if (token) {
+						localStorage.setItem('scrapeToken', token);
+					}
+				} catch (e) {
+					console.error('Error saving token to local storage', e);
+				}
+			},
+			async clearToken() {
+				localStorage.removeItem('scrapeToken');
+				document.getElementById('token').value = '';
+			},
 		}
 	}
 </script>

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -49,26 +49,33 @@
 		.token-controls {
 			display: flex;
 			justify-content: space-between;
-			/* background-color: #3d997d; */
 		}
 		.token-entry {
 			flex-grow: 1;
 			min-width: 400px;
 			margin-right: 0.6rem;
-			/* border: 1px solid #000; */
-			color: #b9e29c;
 		}
 		.token-textarea {
-			/* border: 0.1rem inset #ccc; */
 			box-sizing: border-box;
 			resize: vertical;
 			width: 100%;
+			height: 100%;
 		}
 		.token-info {
 			white-space: nowrap;
 			display: flex;
+			flex-direction: column;
 			align-items: flex-start;
-			justify-content: flex-start;
+			/* justify-content: flex-start; */
+		}
+		.token-info button {
+			width: 100%;
+			padding: 0.1rem 1.0rem; 
+			cursor: pointer;
+		}
+		.token-info button:first-child {
+			margin-top: 0.1rem;
+			margin-bottom: 0.4rem;
 		}
 		.token-info label {
 			display: block;
@@ -116,8 +123,8 @@
 			<textarea class="token-textarea" id="token" rows="2" placeholder="Enter your access token here">{{AuthToken}}</textarea>
 		</div>
 		<div class="token-info">
-			<input type="checkbox" id="saveToken">
-            <label for="saveToken">Save this token</label>
+			<button class="button">Save Token</button>
+            <button class="button">Clear Token</button>
 		</div>
 	</div>
 </div>

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -94,16 +94,6 @@
 			margin-top: 0.1rem;
 			margin-bottom: 0.4rem;
 		}
-		.token-info label {
-			display: block;
-			margin-inline: 0.2rem;
-			margin-block: 0;
-			font-family: Verdana, Arial, Helvetica, sans-serif;
-			font-size: 0.8rem;
-		}
-		.token-info input[type="checkbox"] {
-			vertical-align: middle;
-		}
 		.response-container {
 			width: 100%;
 			flex: 1;

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -60,8 +60,8 @@
 	<option value="/extract/headless">Headless</option>
 	<option value="/feed">Feed</option>
 </select>
-<label for="token">Token:</label>
-<input type="text" name="token" size="101" maxlength="255" value="{{AuthToken}}" placeholder="Enter your access token">
+<!-- <label for="token">Token:</label> -->
+<input type="hidden" name="token" size="101" maxlength="255" value="{{AuthToken}}" placeholder="Enter your access token">
 <input type="hidden" name="pp" value="1">
 </form>
 </div><!-- controls-container -->

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -14,24 +14,29 @@
 		label {
   			margin: 0.2rem 0;
 		}
-		.data-iframe {
-  			position: relative;
-  			top: 16px; 
-  			width: 98%;
-  			min-width: 768px;
-  			height: calc(100vh - 108px); 
+		pre {
+			white-space: pre-wrap;
+			width: 100%;
+		}
+		.response-container {
+			width: 100%;
+			min-width: 768px;
+			height: calc(100vh - 108px);
+			overflow: auto;
+			border: 0.1rem inset #ccc;
+			padding-block: 0.0rem;
+			padding-inline: 0.4rem;
+			box-sizing: border-box;			
 		}
 	</style>
 </head>
 <body>
 <p>
-<form action="/extract" x-data="formHandler" @submit.prevent="handleSubmit">
-
-<!-- <form id="urlForm" action="/extract" method="POST" name="scrape" target="data-iframe" x-data="formHandler" @submit.prevent="handleSubmit"> -->
+<form x-data="formHandler" @submit.prevent="handleSubmit">
 <label for="url">Enter a URL:</label>
 <input type="submit" value="Hit It">
 <input type="url" name="url" id="url" value="https://" size="96" maxlength="200" pattern="https?://.*" required title="URL">
-<select title="URL Type" id="actionSelect" onchange="updateFormAction()">
+<select title="URL Type" x-model="formAction">
 	<option value="/extract">Page</option>
 	<option value="/extract/headless">Headless</option>
 	<option value="/feed">Feed</option>
@@ -40,18 +45,16 @@
 <input type="hidden" name="pp" value="1">
 </form>
 </p>
-<script>
-function updateFormAction() {
-    var selected = document.getElementById("actionSelect").value;
-    document.getElementById("urlForm").action = selected;
-}
-</script>
+<div class="response-container">
+	<pre x-ref="responseContent" id="responseContent"></pre>
+</div> 
+
 <script type="text/javascript">
 	function formHandler() {
 		return {
+			formAction: '/extract',
 			async handleSubmit(event) {
 				const form = event.target;
-				const action = form.action;
 				const headers = new Headers();
 				const token = form.token.value;
 				if (token) {
@@ -60,7 +63,7 @@ function updateFormAction() {
 				const formData = new FormData(form);
 				formData.delete('token');
 				try { 
-					const response = await fetch(action, {
+					const response = await fetch(this.formAction, {
 						method: 'POST',
 						headers: headers,
 						body: formData
@@ -80,63 +83,13 @@ function updateFormAction() {
 				}
 			},
 			updateContent(content) {
-				const iframe = document.getElementById('data');
-                const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
-				const preElement = iframeDoc.getElementById('responseContent');
-				preElement.textContent = content;
+				document.getElementById('responseContent').textContent = content;
+				// following should work but doesn't
+				// this.$refs.responseContent.textContent = content;
 			}
 		}
 	}
 </script>
 
-<script type="text/javascript">
-	document.addEventListener('DOMContentLoaded', function() {
-		const iframe = document.getElementById('data');
-		iframe.contentDocument.body.innerHTML = '';
-		const preElement = document.createElement('pre');
-		preElement.style.whiteSpace = 'pre-wrap';
-		preElement.style.width = '100%';
-		preElement.id = 'responseContent'
-		iframe.contentDocument.body.appendChild(preElement);
-	//	const form = document.getElementById('urlForm');
-	// 	form.addEventListener('submit', async function(event) {
-	// 		event.preventDefault();
-	// 		const action = form.action;
-	// 		const headers = new Headers();
-	// 		const token = form.token.value;
-	// 		if (token) {
-	// 			headers.append('Authorization', `Bearer ${token}`);
-	// 		}
-	// 		const formData = new FormData(form);
-	// 		formData.delete('token');
-	// 		try { 
-	// 		const response = await fetch(action, {
-	// 			method: 'POST',
-	// 			headers: headers,
-	// 			body: formData
-	// 		})
-	// 		if (response.ok) {
-	// 			const json = await response.json();
-	// 			const jsonStr = JSON.stringify(json, null, 2);
-	// 			preElement.textContent = jsonStr;
-	// 		} else {
-	// 			const text = await response.text();
-	// 			preElement.textContent = `Error ${response.status}:\n${text}`;
-	// 			throw new Error(`${response.status} - ${text}`);
-	// 		}
-	// 	} catch (error) {
-	// 		console.error(error);
-	// 	}
-	// });
-});
-	</script>
-<div>
-<iframe 
-	id="data"
-	title="Scrape Results"
-	name="data-iframe"
-	class="data-iframe"
-	>
-</div>
 </body>
 </html>

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -4,6 +4,7 @@
 	<meta charset="utf-8" />
 	<title>scrape</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 	<style>
 		label {
 			display: block;
@@ -24,7 +25,9 @@
 </head>
 <body>
 <p>
-<form id="urlForm" action="/extract" method="POST" name="scrape" target="data-iframe">
+<form action="/extract" x-data="formHandler" @submit.prevent="handleSubmit">
+
+<!-- <form id="urlForm" action="/extract" method="POST" name="scrape" target="data-iframe" x-data="formHandler" @submit.prevent="handleSubmit"> -->
 <label for="url">Enter a URL:</label>
 <input type="submit" value="Hit It">
 <input type="url" name="url" id="url" value="https://" size="96" maxlength="200" pattern="https?://.*" required title="URL">
@@ -44,43 +47,87 @@ function updateFormAction() {
 }
 </script>
 <script type="text/javascript">
+	function formHandler() {
+		return {
+			async handleSubmit(event) {
+				const form = event.target;
+				const action = form.action;
+				const headers = new Headers();
+				const token = form.token.value;
+				if (token) {
+					headers.append('Authorization', `Bearer ${token}`);
+				}
+				const formData = new FormData(form);
+				formData.delete('token');
+				try { 
+					const response = await fetch(action, {
+						method: 'POST',
+						headers: headers,
+						body: formData
+					})
+					
+					if (response.ok) {
+						const json = await response.json();
+						const jsonStr = JSON.stringify(json, null, 2);
+						this.updateContent(jsonStr);
+					} else {
+						const text = await response.text();
+						this.updateContent(`Error ${response.status}:\n${text}`);
+						throw new Error(`${response.status} - ${text}`);
+					}
+				} catch (error) {
+					console.error(error);
+				}
+			},
+			updateContent(content) {
+				const iframe = document.getElementById('data');
+                const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
+				const preElement = iframeDoc.getElementById('responseContent');
+				preElement.textContent = content;
+			}
+		}
+	}
+</script>
+
+<script type="text/javascript">
 	document.addEventListener('DOMContentLoaded', function() {
 		const iframe = document.getElementById('data');
 		iframe.contentDocument.body.innerHTML = '';
 		const preElement = document.createElement('pre');
 		preElement.style.whiteSpace = 'pre-wrap';
 		preElement.style.width = '100%';
+		preElement.id = 'responseContent'
 		iframe.contentDocument.body.appendChild(preElement);
-		const form = document.getElementById('urlForm');
-		form.addEventListener('submit', async function(event) {
-			event.preventDefault();
-			const action = form.action;
-			const headers = new Headers();
-			const token = form.token.value;
-			if (token) {
-				headers.append('Authorization', `Bearer ${token}`);
-			}
-			const formData = new FormData(form);
-			formData.delete('token');
-			try { 
-			const response = await fetch(action, {
-				method: 'POST',
-				headers: headers,
-				body: formData
-			})
-			if (response.ok) {
-				const json = await response.json();
-				const jsonStr = JSON.stringify(json, null, 2);
-				preElement.textContent = jsonStr;
-			} else {
-				const text = await response.text();
-				preElement.textContent = `Error ${response.status}:\n${text}`;
-				throw new Error(`${response.status} - ${text}`);
-			}
-		} catch (error) {
-			console.error(error);
-		}
-	});
+	//	const form = document.getElementById('urlForm');
+	// 	form.addEventListener('submit', async function(event) {
+	// 		event.preventDefault();
+	// 		const action = form.action;
+	// 		const headers = new Headers();
+	// 		const token = form.token.value;
+	// 		if (token) {
+	// 			headers.append('Authorization', `Bearer ${token}`);
+	// 		}
+	// 		const formData = new FormData(form);
+	// 		formData.delete('token');
+	// 		try { 
+	// 		const response = await fetch(action, {
+	// 			method: 'POST',
+	// 			headers: headers,
+	// 			body: formData
+	// 		})
+	// 		if (response.ok) {
+	// 			const json = await response.json();
+	// 			const jsonStr = JSON.stringify(json, null, 2);
+	// 			preElement.textContent = jsonStr;
+	// 		} else {
+	// 			const text = await response.text();
+	// 			preElement.textContent = `Error ${response.status}:\n${text}`;
+	// 			throw new Error(`${response.status} - ${text}`);
+	// 		}
+	// 	} catch (error) {
+	// 		console.error(error);
+	// 	}
+	// });
 });
 	</script>
 <div>

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -6,6 +6,37 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 	<style>
+		body, html {
+			margin: 0;
+			padding: 0;
+			height: 100vh;
+		}
+		.page-container {
+			display: flex;
+			flex-direction: column;
+			gap: 0.6rem;
+			box-sizing: border-box;
+			height: 100%;
+			padding: 0.6rem;
+		}
+		.controls-container {
+			background-color: #fff;
+			box-sizing: border-box;
+		}
+		.response-container {
+			width: 100%;
+			min-width: 768px;
+			flex: 1;
+			overflow: auto;
+			border: 0.1rem inset #ccc;
+			padding-block: 0.2rem;
+			padding-inline: 0.4rem;
+			box-sizing: border-box;
+		}
+		pre {
+			white-space: pre-wrap;
+			width: 100%;
+		}
 		label {
 			display: block;
 			font: 1rem 'Verdana'
@@ -14,24 +45,12 @@
 		label {
   			margin: 0.2rem 0;
 		}
-		pre {
-			white-space: pre-wrap;
-			width: 100%;
-		}
-		.response-container {
-			width: 100%;
-			min-width: 768px;
-			height: calc(100vh - 108px);
-			overflow: auto;
-			border: 0.1rem inset #ccc;
-			padding-block: 0.0rem;
-			padding-inline: 0.4rem;
-			box-sizing: border-box;			
-		}
+		
 	</style>
 </head>
 <body>
-<p>
+<div class="page-container">
+<div class="controls-container">
 <form x-data="formHandler" @submit.prevent="handleSubmit">
 <label for="url">Enter a URL:</label>
 <input type="submit" value="Hit It">
@@ -41,14 +60,15 @@
 	<option value="/extract/headless">Headless</option>
 	<option value="/feed">Feed</option>
 </select>
-<input type="hidden" name="token" value="{{AuthToken}}">
+<label for="token">Token:</label>
+<input type="text" name="token" size="101" maxlength="255" value="{{AuthToken}}" placeholder="Enter your access token">
 <input type="hidden" name="pp" value="1">
 </form>
-</p>
+</div><!-- controls-container -->
 <div class="response-container">
 	<pre x-ref="responseContent" id="responseContent"></pre>
 </div> 
-
+</div><!-- page-container -->
 <script type="text/javascript">
 	function formHandler() {
 		return {


### PR DESCRIPTION
This PR:

1.  Adds the ability to enter a token into the scrape test console
  - The token entry widget only appears when the server is running with authentication enabled
1. Lets the user save the token to local storage, and loads that token on page load if present. This is here to make managing the tokens and using the test console less of a hassle.
1. Makes the page generally more responsive and with a more coherent box model, following on the updates in https://github.com/Pocket/scrape/pull/6

NB: There are still no material changes to auth behavior in this PR. IOW, The server will still supply a short-lived token to auth the test console when auth is enabled. I'll be addressing that in the next PR, there were enough changes here that I wanted to keep that behavior separate, and focus on the frontend changes here.

## Decisions and Requested Feedback

In general, I think the additions here are pretty slick ( ;) ) and I'm happy both to see a more modern HTML structure and for myself to get better versed in flexbox and such. That said, the CSS in particular seems a little more ungainly in this rev I'm happy for any suggestions on making that and the page structure generally, leaner.

Also [within the boundaries of things that are easy to accomplish] would love UX feedback.

## Steps to Test 

The things to test here are mainly that the form, and especially the new addition for tokens, works and seems comprehensible. (Note that you'll still get a pre-populated token in this release, which will be dropped in the next PR; so you can test the operations, but just keep in mind that in the future that will be blank)

The html for this page can be viewed and interacted with pretty well by just opening the index.html file in your browser. Form submissions obviously won't work, but testing without a running server _can_ cover the important bases. **So, if you can't run the server, you can still review the code and most of the UX without doing that.**

If you're executed a full test with the server: Since the test console will only show the new token entry widget when authentication is enabled, and as authentication is enabled on startup, you'll need to start the server two different ways to get a full and comprehensive test. 

### Building this PR 

- Check out the branch

#### Without Go on your machine

- In the branch root: 
  - `make docker-build`

#### With Go 1.22.x on your machine

- In the branch root: 
  - `make`

### Authentication Disabled

In this case, you're just verifying that the server still works and that there's no token management artifacts visible here.  The only visible changes here are that the url entry field is now responsive, and there's a border around the form.

#### Starting the server

Docker: `make docker-run`
Binary: `./build/scrape-server`

#### Testing

Enter a url in the url entry field and `Hit It`, etc.

### Authentication Enabled 

The meat of the changes in this PR are visible when Authentication is enabled.
 
####  Starting the Server

Authentication is enabled in `scrape-server` by providing a signing key to the server at startup. This can be done via a command line flag or an environment variable. 

Here's a signing key for testing: 

```
bCdcAT8EBvQXo7A50c4cSbkTc2gMvpVoMYrVaOpuKmM=
```
Is a signing key that you can use to enable authentication as shown below

#### Starting the server with authentication enabled: 

Using Docker:

- In your Docker Desktop find the `scrape-bookworm-slim` image you just built. If it's running, stop it.
- Click the play button
- When the modal opens, expand `Optional Settings`
- For host port, enter `8080`
- Make an environment variable called `SCRAPE_SIGNING_KEY`
- Set its value to the signing key above

Using a binary you built:

This is a little easier since you can just pass a command line flag containing the signing key

```
./build/scrape-server -signing-key bCdcAT8EBvQXo7A50c4cSbkTc2gMvpVoMYrVaOpuKmM=
```
#### Stuff to test (finally) 

The `Enter Token` button will show and hide the token entry field, along with other buttons to save and clear the token, as noted above. Generally exercise these, feedback welcome!
